### PR TITLE
[JENKINS-59252] Use last committer of the affected file of warning lineNumber == 0.

### DIFF
--- a/src/test/java/io/jenkins/plugins/git/forensics/blame/GitBlamerITest.java
+++ b/src/test/java/io/jenkins/plugins/git/forensics/blame/GitBlamerITest.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import org.jenkinsci.plugins.gitclient.GitClient;
@@ -82,7 +83,7 @@ public class GitBlamerITest extends GitITest {
     /**
      * Verifies that the last committer of the whole file is used if no specific line number is given.
      */
-    @Test
+    @Test @Issue("JENKINS-59252")
     public void shouldAssignLastCommitterIfNoLineNumberIsGiven() {
         create2RevisionsWithDifferentAuthors();
 

--- a/src/test/java/io/jenkins/plugins/git/forensics/blame/GitBlamerITest.java
+++ b/src/test/java/io/jenkins/plugins/git/forensics/blame/GitBlamerITest.java
@@ -79,6 +79,33 @@ public class GitBlamerITest extends GitITest {
         assertThatBlameIsEmpty(request, 6);
     }
 
+    /**
+     * Verifies that the last committer of the whole file is used if no specific line number is given.
+     */
+    @Test
+    public void shouldAssignLastCommitterIfNoLineNumberIsGiven() {
+        create2RevisionsWithDifferentAuthors();
+
+        FileLocations locations = new FileLocations(sampleRepo.getRoot());
+        String absolutePath = locations.getWorkspace() + FILE_NAME;
+        locations.addLine(absolutePath, 0);
+
+        GitBlamer gitBlamer = createBlamer();
+
+        Blames blames = gitBlamer.blame(locations);
+
+        assertThat(blames.getFiles()).isNotEmpty().containsExactly(absolutePath);
+        assertThat(blames.getErrorMessages()).isEmpty();
+        assertThat(blames.getInfoMessages()).contains("-> blamed authors of issues in 1 files");
+
+        FileBlame request = blames.getBlame(absolutePath);
+        assertThat(request).hasFileName(absolutePath);
+
+        assertThat(request.getName(0)).isEqualTo(BAR_NAME);
+        assertThat(request.getEmail(0)).isEqualTo(BAR_EMAIL);
+        assertThat(request.getCommit(0)).isEqualTo(getHead());
+    }
+
     private GitBlamer createBlamer() {
         try {
             GitSCM scm = new GitSCM(


### PR DESCRIPTION
See [JENKINS-59252](https://issues.jenkins-ci.org/browse/JENKINS-59252).

Some tools do not report line numbers for warnings, some other tools use line number 0 to indicate that the warning is  for the whole file. In those cases, the blame information should be taken from the last commit for the affected file. 