### PR TITLE
[JENKINS-60014] Add the time of a commit to the blame.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <eclipse-collections.version>9.2.0</eclipse-collections.version>
 
     <!-- Jenkins Plugin Dependencies Versions -->
-    <forensics-api-plugin.version>0.5.0</forensics-api-plugin.version>
+    <forensics-api-plugin.version>0.6.0</forensics-api-plugin.version>
     <git-plugin.version>3.9.1</git-plugin.version>
 
     <!-- Test Library Dependencies Versions -->

--- a/src/main/java/io/jenkins/plugins/forensics/git/blame/GitBlamer.java
+++ b/src/main/java/io/jenkins/plugins/forensics/git/blame/GitBlamer.java
@@ -208,10 +208,11 @@ class GitBlamer extends Blamer {
             }
             RevCommit commit = blame.getSourceCommit(lineIndex);
             if (commit == null) {
-                blames.logError("- no commit ID found for line %d in file %s", lineIndex, fileName);
+                blames.logError("- no commit ID and time found for line %d in file %s", lineIndex, fileName);
             }
             else {
                 fileBlame.setCommit(line, commit.getName());
+                fileBlame.setTime(line, commit.getCommitTime());
             }
         }
 

--- a/src/test/java/io/jenkins/plugins/forensics/git/blame/GitBlamerTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/git/blame/GitBlamerTest.java
@@ -18,6 +18,8 @@ import org.jvnet.hudson.test.Issue;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.jenkinsci.plugins.gitclient.GitClient;
 import hudson.FilePath;
 import hudson.plugins.git.GitException;
@@ -285,11 +287,12 @@ class GitBlamerTest {
     private RevCommit createCommit() {
         return createCommit(TIME);
     }
-    
+
+    @SuppressFBWarnings(value = "VA_FORMAT_STRING_USES_NEWLINE", justification = "JGit apparently can't parse windows line-endings (\r\n)")
     private RevCommit createCommit(final int commitTime) {
-        String commitData = String.format("tree %040x%n"
-                        + "author Foo Bar <foo@bar.com> %d +0000%n"
-                        + "committer Foo Bar <foo@bar.com> %d +0000%n%n"
+        String commitData = String.format("tree %040x\n"
+                        + "author Foo Bar <foo@bar.com> %d +0000\n"
+                        + "committer Foo Bar <foo@bar.com> %d +0000\n\n"
                         + "Commit message",
                 new Random().nextLong(),
                 commitTime,

--- a/src/test/java/io/jenkins/plugins/forensics/git/blame/GitBlamerTest.java
+++ b/src/test/java/io/jenkins/plugins/forensics/git/blame/GitBlamerTest.java
@@ -212,6 +212,7 @@ class GitBlamerTest {
         assertThat(blame.getEmail(3)).isEqualTo(EMPTY);
         assertThat(blame.getName(3)).isEqualTo(EMPTY);
         assertThat(blame.getCommit(3)).isEqualTo(EMPTY);
+        assertThat(blame.getTime(3)).isEqualTo(EMPTY_TIME);
 
         callback.run("otherFile", "otherFile", blameRunner, lastCommitRunner);
         assertThat(blames.getErrorMessages()).contains("- no blame results for file 'otherFile'");
@@ -257,7 +258,7 @@ class GitBlamerTest {
         assertThat(blame.getEmail(1)).isEqualTo(EMPTY);
         assertThat(blame.getName(1)).isEqualTo(EMPTY);
         assertThat(blame.getCommit(1)).isNotBlank().isNotEqualTo(EMPTY);
-        assertThat(blame.getTime(1)).isNotEqualTo(EMPTY_TIME);
+        assertThat(blame.getTime(1)).isEqualTo(TIME);
     }
 
     @Test
@@ -286,14 +287,13 @@ class GitBlamerTest {
     }
     
     private RevCommit createCommit(final int commitTime) {
-        String commitData = String.format("tree %040x\n"
-                        + "author Foo Bar <foo@bar.com> %d +0000\n"
-                        + "committer Foo Bar <foo@bar.com> %d +0000\n\n"
-                        + "%s",
+        String commitData = String.format("tree %040x%n"
+                        + "author Foo Bar <foo@bar.com> %d +0000%n"
+                        + "committer Foo Bar <foo@bar.com> %d +0000%n%n"
+                        + "Commit message",
                 new Random().nextLong(),
                 commitTime,
-                commitTime,
-                "Commit message");
+                commitTime);
         return RevCommit.parse(commitData.getBytes());
     }
 
@@ -327,6 +327,6 @@ class GitBlamerTest {
         assertThat(request.getEmail(line)).isEqualTo(EMAIL + line);
         assertThat(request.getName(line)).isEqualTo(NAME + line);
         assertThat(request.getCommit(line)).isNotBlank().isNotEqualTo(EMPTY); // final getter
-        assertThat(request.getTime(line)).isNotEqualTo(EMPTY_TIME);
+        assertThat(request.getTime(line)).isEqualTo(TIME);
     }
 }


### PR DESCRIPTION
See [JENKINS-60014](https://issues.jenkins-ci.org/browse/JENKINS-60014).

Introduce the time of a commit to the blame. This enables the user to see not only who made a change, but also when the change was made.

This implements the changes from the forensics-api-plugin (https://github.com/jenkinsci/forensics-api-plugin/pull/47). As long as the PR there is not merged and the new version of the maven package is not released, the present pull request will not build.