### PR TITLE
[JENKINS-64545] Fix NPE 

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.forensics.git.reference;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import edu.hm.hafner.util.VisibleForTesting;
@@ -80,8 +81,12 @@ public class GitReferenceRecorder extends ReferenceRecorder {
 
     @Override
     protected Optional<Run<?, ?>> find(final Run<?, ?> owner, final Run<?, ?> lastCompletedBuildOfReferenceJob) {
-        GitCommitsRecord thisCommit = owner.getAction(GitCommitsRecord.class);
         GitCommitsRecord referenceCommit = lastCompletedBuildOfReferenceJob.getAction(GitCommitsRecord.class);
+        if (referenceCommit == null) {
+            return Optional.empty();
+        }
+
+        GitCommitsRecord thisCommit = Objects.requireNonNull(owner.getAction(GitCommitsRecord.class));
 
         return thisCommit.getReferencePoint(referenceCommit, getMaxCommits(), isSkipUnknownCommits());
     }

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/package-info.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/package-info.java
@@ -1,0 +1,22 @@
+/**
+ *  Provides classes to discover reference builds in Git projects.
+ * <p>
+ * Several plugins that report build statistics (test results, code coverage, metrics, static analysis warnings)
+ * typically show their reports in two different ways: either as absolute report (e.g., total number of tests or
+ * warnings, overall code coverage) or as relative delta report (e.g., additional tests, increased or decreased
+ * coverage, new or fixed warnings). In order to compute a relative delta report a plugin needs to carefully select the
+ * other build to compare the current results to (a so called reference build). For simple Jenkins jobs that build the
+ * main branch of an SCM the reference build will be selected from one of the previous builds of the same job. For more
+ * complex branch source projects (i.e., projects that build several branches and pull requests in a connected job
+ * hierarchy) it makes more sense to select a reference build from a job that builds the actual target branch (i.e., the
+ * branch the current changes will be merged into). Here one typically is interested what changed in a branch or pull
+ * request with respect to the main branch (or any other target branch): e.g., how will the code coverage change if the
+ * team merges the changes. Selecting the correct reference build is not that easy, since the main branch of a project
+ * will evolve more frequently than a specific feature or bugfix branch.
+ * </p>
+ */
+@DefaultAnnotation(NonNull.class)
+package io.jenkins.plugins.forensics.git.reference;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;

--- a/ui-tests/src/test/java/io/jenkins/plugins/forensics/ForensicsPluginUiTest.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/forensics/ForensicsPluginUiTest.java
@@ -72,7 +72,7 @@ public class ForensicsPluginUiTest extends AbstractJUnitTest {
     private GitScm createGitScm(final FreeStyleJob job) {
         GitScm gitScm = job.useScm(GitScm.class);
 
-        WebDriverWait wait = new WebDriverWait(driver, 2, 100);
+        WebDriverWait wait = new WebDriverWait(driver, 10);
         WebElement url = gitScm.find(By.xpath(".//input[contains(@name, '_.url')]"));
         wait.withTimeout(Duration.ofSeconds(10)).until(ExpectedConditions.elementToBeClickable(url));
 
@@ -216,7 +216,7 @@ public class ForensicsPluginUiTest extends AbstractJUnitTest {
 
     private FreeStyleJob createFreeStyleJob(final String... resourcesToCopy) {
         FreeStyleJob job = jenkins.getJobs().create(FreeStyleJob.class);
-        ScrollerUtil.hideScrollerTabBar(driver);
+        // ScrollerUtil.hideScrollerTabBar(driver);
         for (String resource : resourcesToCopy) {
             job.copyResource("/" + resource);
         }

--- a/ui-tests/src/test/java/io/jenkins/plugins/forensics/ForensicsPluginUiTest.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/forensics/ForensicsPluginUiTest.java
@@ -33,9 +33,8 @@ public class ForensicsPluginUiTest extends AbstractJUnitTest {
         FreeStyleJob job = createFreeStyleJob();
         job.addPublisher(ForensicsPublisher.class);
 
-        job.useScm(GitScm.class)
-                .url(REPOSITORY_URL)
-                .branch("28af63def44286729e3b19b03464d100fd1d0587");
+        GitScm gitScm = createGitScm(job);
+        gitScm.url(REPOSITORY_URL).branch("28af63def44286729e3b19b03464d100fd1d0587");
         job.save();
         Build build = buildSuccessfully(job);
 
@@ -66,6 +65,12 @@ public class ForensicsPluginUiTest extends AbstractJUnitTest {
                 "in 131 files");
     }
 
+    private GitScm createGitScm(final FreeStyleJob job) {
+        GitScm gitScm = job.useScm(GitScm.class);
+        gitScm.waitFor();
+        return gitScm;
+    }
+
     private String getSummaryText(final Build referenceBuild, final int row) {
         return referenceBuild.getElement(
                 By.xpath("/html/body/div[4]/div[2]/table/tbody/tr[" + row + "]/td[2]")).getText();
@@ -79,9 +84,8 @@ public class ForensicsPluginUiTest extends AbstractJUnitTest {
         FreeStyleJob job = createFreeStyleJob();
         job.addPublisher(ForensicsPublisher.class);
 
-        job.useScm(GitScm.class)
-                .url(REPOSITORY_URL)
-                .branch("28af63def44286729e3b19b03464d100fd1d0587");
+        GitScm gitScm = createGitScm(job);
+        gitScm.url(REPOSITORY_URL).branch("28af63def44286729e3b19b03464d100fd1d0587");
         job.save();
         Build build = buildSuccessfully(job);
 

--- a/ui-tests/src/test/java/io/jenkins/plugins/forensics/ForensicsPluginUiTest.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/forensics/ForensicsPluginUiTest.java
@@ -1,9 +1,13 @@
 package io.jenkins.plugins.forensics;
 
+import java.time.Duration;
 import java.util.List;
 
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import org.jenkinsci.test.acceptance.junit.AbstractJUnitTest;
 import org.jenkinsci.test.acceptance.junit.WithPlugins;
@@ -67,7 +71,11 @@ public class ForensicsPluginUiTest extends AbstractJUnitTest {
 
     private GitScm createGitScm(final FreeStyleJob job) {
         GitScm gitScm = job.useScm(GitScm.class);
-        gitScm.waitFor();
+
+        WebDriverWait wait = new WebDriverWait(driver, 2, 100);
+        WebElement url = gitScm.find(By.xpath(".//input[contains(@name, '_.url')]"));
+        wait.withTimeout(Duration.ofSeconds(10)).until(ExpectedConditions.elementToBeClickable(url));
+
         return gitScm;
     }
 


### PR DESCRIPTION
Fix NPE if reference job does not yet have a `GitCommitsRecord` action attached.

See https://issues.jenkins-ci.org/browse/JENKINS-64545.