### PR TITLE
[JENKINS-64578] Support multiple SCM repositories per job

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -77,6 +77,11 @@
         <artifactId>script-security</artifactId>
         <version>1.75</version>
       </dependency>
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>echarts-api</artifactId>
+        <version>4.9.0-3</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -30,7 +30,7 @@
     <!-- Jenkins Plugin Dependencies Versions -->
     <plugin-util-api.version>1.6.1</plugin-util-api.version>
     <data-tables-api.version>1.10.21-3</data-tables-api.version>
-    <forensics-api-plugin.version>0.9.0-rc764.c5918d021b14</forensics-api-plugin.version>
+    <forensics-api-plugin.version>0.9.0-rc765.be08e4f19b71</forensics-api-plugin.version>
 
     <git-plugin.version>4.4.5</git-plugin.version>
     <git-client.version>3.5.1</git-client.version>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -30,7 +30,7 @@
     <!-- Jenkins Plugin Dependencies Versions -->
     <plugin-util-api.version>1.6.1</plugin-util-api.version>
     <data-tables-api.version>1.10.21-3</data-tables-api.version>
-    <forensics-api-plugin.version>0.9.0-rc749.2cad0a8fee61</forensics-api-plugin.version>
+    <forensics-api-plugin.version>0.9.0-rc762.26d891afcc87</forensics-api-plugin.version>
 
     <git-plugin.version>4.4.5</git-plugin.version>
     <git-client.version>3.5.1</git-client.version>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -30,7 +30,7 @@
     <!-- Jenkins Plugin Dependencies Versions -->
     <plugin-util-api.version>1.6.1</plugin-util-api.version>
     <data-tables-api.version>1.10.21-3</data-tables-api.version>
-    <forensics-api-plugin.version>0.8.1</forensics-api-plugin.version>
+    <forensics-api-plugin.version>0.9.0-rc749.2cad0a8fee61</forensics-api-plugin.version>
 
     <git-plugin.version>4.4.5</git-plugin.version>
     <git-client.version>3.5.1</git-client.version>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -30,7 +30,7 @@
     <!-- Jenkins Plugin Dependencies Versions -->
     <plugin-util-api.version>1.6.1</plugin-util-api.version>
     <data-tables-api.version>1.10.21-3</data-tables-api.version>
-    <forensics-api-plugin.version>0.9.0-rc769.58707d06946b</forensics-api-plugin.version>
+    <forensics-api-plugin.version>0.9.0</forensics-api-plugin.version>
 
     <git-plugin.version>4.4.5</git-plugin.version>
     <git-client.version>3.5.1</git-client.version>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -30,7 +30,7 @@
     <!-- Jenkins Plugin Dependencies Versions -->
     <plugin-util-api.version>1.6.1</plugin-util-api.version>
     <data-tables-api.version>1.10.21-3</data-tables-api.version>
-    <forensics-api-plugin.version>0.9.0-rc765.be08e4f19b71</forensics-api-plugin.version>
+    <forensics-api-plugin.version>0.9.0-rc769.58707d06946b</forensics-api-plugin.version>
 
     <git-plugin.version>4.4.5</git-plugin.version>
     <git-client.version>3.5.1</git-client.version>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -30,7 +30,7 @@
     <!-- Jenkins Plugin Dependencies Versions -->
     <plugin-util-api.version>1.6.1</plugin-util-api.version>
     <data-tables-api.version>1.10.21-3</data-tables-api.version>
-    <forensics-api-plugin.version>0.9.0-rc762.26d891afcc87</forensics-api-plugin.version>
+    <forensics-api-plugin.version>0.9.0-rc764.c5918d021b14</forensics-api-plugin.version>
 
     <git-plugin.version>4.4.5</git-plugin.version>
     <git-client.version>3.5.1</git-client.version>

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/util/GitRepositoryValidator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/util/GitRepositoryValidator.java
@@ -130,4 +130,22 @@ public class GitRepositoryValidator {
         }
         return HEAD;
     }
+
+    /**
+     * Returns the key for the associated SCM.
+     *
+     * @return the SCM key
+     */
+    public String getId() {
+        return scm.getKey();
+    }
+
+    /**
+     * Returns the associated SCM.
+     *
+     * @return the SCM
+     */
+    public SCM getScm() {
+        return scm;
+    }
 }

--- a/plugin/src/main/resources/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder/config.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder/config.jelly
@@ -9,6 +9,10 @@
     <f:textbox/>
   </f:entry>
 
+  <f:entry title="${%title.scm}" field="scm" description="${%description.scm}">
+    <f:textbox/>
+  </f:entry>
+
   <f:entry title="${%title.maxCommits}" description="${%description.maxCommits}" field="maxCommits">
     <f:number default="100"/>
   </f:entry>

--- a/plugin/src/main/resources/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder/config.properties
+++ b/plugin/src/main/resources/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder/config.properties
@@ -1,5 +1,7 @@
 title.referenceJob=Reference Job
 description.referenceJob=A reference job defines the baseline for tools that want to create relative build reports.
+title.scm=SCM Key
+description.scm=Specify the key of your repository (substring) if you are using multiple SCMs in your job.
 title.maxCommits=#Commits
 description.maxCommits=Defines how many commits of a job's Git history should be evaluated to find the reference build.
 title.defaultBranch=Default Branch

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/miner/GitMinerStepITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/miner/GitMinerStepITest.java
@@ -30,7 +30,12 @@ import static io.jenkins.plugins.forensics.assertions.Assertions.*;
  * @author Ullrich Hafner
  */
 public class GitMinerStepITest extends GitITest {
-    private static final String REPOSITORY_URL = "https://github.com/jenkinsci/git-forensics-plugin.git";
+    private static final String GIT_FORENSICS_URL = "https://github.com/jenkinsci/git-forensics-plugin.git";
+    private static final String FORENSICS_API_URL = "https://github.com/jenkinsci/forensics-api-plugin.git";
+    private static final String FORENSICS_API_COMMIT = "a6d0ef09ab3c418e370449a884da99b8190ae950";
+    private static final String GIT_FORENSICS_COMMIT = "86503e8bc0374e05e2cd32ed3bb8b4435d5fd757";
+    private static final int EXPECTED_FILES_GIT_FORENSICS = 90;
+    private static final int EXPECTED_FILES_FORENSICS_API = 121;
 
     /** Verifies that the table contains two rows with the correct statistics. */
     @Test
@@ -213,28 +218,92 @@ public class GitMinerStepITest extends GitITest {
     public void shouldRunOnExistingProject() throws IOException {
         FreeStyleProject job = createFreeStyleProject();
         GitSCM scm = new GitSCM(GitSCM.createRepoList("https://github.com/jenkinsci/git-forensics-plugin.git", null),
-                Collections.singletonList(new BranchSpec("28af63def44286729e3b19b03464d100fd1d0587")),
+                Collections.singletonList(new BranchSpec(GIT_FORENSICS_COMMIT)),
                 false, Collections.emptyList(), null, null, Collections.emptyList());
         job.setScm(scm);
         job.getPublishersList().add(new RepositoryMinerStep());
 
         Run<?, ?> build = buildSuccessfully(job);
         RepositoryStatistics statistics = getStatistics(build);
-        assertThat(statistics.getFiles()).hasSize(51);
+        assertThat(statistics.getFiles()).hasSize(EXPECTED_FILES_GIT_FORENSICS);
     }
 
     /** Run on existing project. */
     @Test
     public void shouldRunInPipelineOnExistingProject() {
         WorkflowJob job = createPipeline();
+        job.setDefinition(asStage(checkout(GIT_FORENSICS_COMMIT, GIT_FORENSICS_URL), "mineRepository()"));
+
+        assertThat(buildSuccessfully(job).getActions(ForensicsBuildAction.class))
+                .hasSize(1)
+                .element(0).satisfies(this::verifyGitForensics);
+    }
+
+    /**
+     * Creates a pipeline that checks out two different repositories and verifies that both repositories will be mined.
+     */
+    @Test
+    public void shouldMineMultipleRepositories() {
+        WorkflowJob job = createPipeline();
         job.setDefinition(asStage(
-                "checkout([$class: 'GitSCM', "
-                        + "branches: [[name: '28af63def44286729e3b19b03464d100fd1d0587' ]],\n"
-                        + "userRemoteConfigs: [[url: '" + REPOSITORY_URL + "']]])",
+                checkout(GIT_FORENSICS_COMMIT, GIT_FORENSICS_URL),
+                checkout(FORENSICS_API_COMMIT, FORENSICS_API_URL),
                 "mineRepository()"));
-        Run<?, ?> build = buildSuccessfully(job);
-        RepositoryStatistics statistics = getStatistics(build);
-        assertThat(statistics.getFiles()).hasSize(51);
+
+        List<ForensicsBuildAction> actions = buildSuccessfully(job).getActions(ForensicsBuildAction.class);
+
+        assertThat(actions).hasSize(2);
+        verifyGitForensics(actions.get(0));
+        verifyForensicsApi(actions.get(1), "forensics-1");
+    }
+
+    /**
+     * Creates a pipeline that checks out two different repositories and verifies that both repositories will be mined.
+     */
+    @Test
+    public void shouldMineSelectedRepository() {
+        WorkflowJob job = createPipeline();
+        job.setDefinition(asStage(
+                checkout(GIT_FORENSICS_COMMIT, GIT_FORENSICS_URL),
+                checkout(FORENSICS_API_COMMIT, FORENSICS_API_URL),
+                "mineRepository(scm: 'forensics-api')"));
+
+        List<ForensicsBuildAction> forensicsActions = buildSuccessfully(job).getActions(ForensicsBuildAction.class);
+
+        assertThat(forensicsActions).hasSize(1);
+        verifyForensicsApi(forensicsActions.get(0), "forensics");
+
+        job.setDefinition(asStage(
+                checkout(GIT_FORENSICS_COMMIT, GIT_FORENSICS_URL),
+                checkout(FORENSICS_API_COMMIT, FORENSICS_API_URL),
+                "mineRepository(scm: 'git-forensics')"));
+
+        List<ForensicsBuildAction> gitForensicsActions = buildSuccessfully(job).getActions(ForensicsBuildAction.class);
+
+        assertThat(gitForensicsActions).hasSize(1);
+        verifyGitForensics(gitForensicsActions.get(0));
+    }
+
+    private void verifyForensicsApi(final ForensicsBuildAction forensicsApi, final String expectedUrl) {
+        assertThat(forensicsApi.getUrlName()).isEqualTo(expectedUrl);
+        assertThat(forensicsApi.getNumberOfFiles()).isEqualTo(EXPECTED_FILES_FORENSICS_API);
+        assertThat(forensicsApi.getScmKey()).contains("forensics-api");
+        assertThat(forensicsApi.getResult()).hasLatestCommitId(FORENSICS_API_COMMIT);
+    }
+
+    private void verifyGitForensics(final ForensicsBuildAction gitForensics) {
+        assertThat(gitForensics.getUrlName()).isEqualTo("forensics");
+        assertThat(gitForensics.getNumberOfFiles()).isEqualTo(EXPECTED_FILES_GIT_FORENSICS);
+        assertThat(gitForensics.getScmKey()).contains("git-forensics");
+        assertThat(gitForensics.getResult()).hasLatestCommitId(GIT_FORENSICS_COMMIT);
+    }
+
+    private String checkout(final String commitId, final String repositoryUrl) {
+        return "checkout([$class: 'GitSCM', "
+                + "branches: [[name: '" + commitId + "' ]],\n"
+                + "userRemoteConfigs: [[url: '" + repositoryUrl + "']],\n"
+                + "extensions: [[$class: 'RelativeTargetDirectory', \n"
+                + "            relativeTargetDir: '" + commitId + "']]])";
     }
 
     private void verifyStatistics(final RepositoryStatistics statistics, final String fileName,

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitCheckoutListenerITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitCheckoutListenerITest.java
@@ -110,7 +110,10 @@ public class GitCheckoutListenerITest extends IntegrationTestWithJenkinsPerSuite
                 .hasValue(first.getOwner());
     }
 
-    /** Run on existing project. */
+    /**
+     * Creates a pipeline that checks out two different repositories and verifies that the decorator correctly will
+     * be attached to both of them.
+     */
     @Test
     public void shouldDecorateSeveralRepositories() {
         WorkflowJob job = createPipeline();

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderITest.java
@@ -11,6 +11,8 @@ import org.jvnet.hudson.test.Issue;
 
 import com.cloudbees.hudson.plugins.folder.computed.FolderComputation;
 
+import edu.hm.hafner.util.PathUtil;
+
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -193,7 +195,7 @@ public class GitReferenceRecorderITest extends GitITest {
     }
 
     private String getUrl() {
-        return "userRemoteConfigs: [[url: 'file://" + sampleRepo.toString() + "']],\n";
+        return "userRemoteConfigs: [[url: 'file://" + new PathUtil().getAbsolutePath(sampleRepo.toString()) + "']],\n";
     }
 
     /**

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderITest.java
@@ -41,7 +41,7 @@ import static org.jvnet.hudson.test.JenkinsRule.*;
 // TODO: add test case that merges with master
 // TODO: add freestyle tests
 // TODO: add test if a recorded reference build is deleted afterwards
-@SuppressWarnings("checkstyle:IllegalCatch")
+@SuppressWarnings({"checkstyle:IllegalCatch", "PMD.GodClass"})
 public class GitReferenceRecorderITest extends GitITest {
     private static final String FORENSICS_API_URL = "https://github.com/jenkinsci/forensics-api-plugin.git";
 

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderITest.java
@@ -94,7 +94,8 @@ public class GitReferenceRecorderITest extends GitITest {
         createFeatureBranchAndAddCommits();
 
         WorkflowJob featureBranch = createPipeline("feature");
-        featureBranch.setDefinition(asStage(createLocalGitCheckout("feature")));
+        featureBranch.setDefinition(asStage(createLocalGitCheckout("feature"),
+                "discoverGitReferenceBuild(referenceJob: 'main')"));
 
         verifyPipelineResult(masterBuild, featureBranch);
     }

--- a/ui-tests/src/test/java/io/jenkins/plugins/forensics/ForensicsPluginUiTest.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/forensics/ForensicsPluginUiTest.java
@@ -51,7 +51,7 @@ public class ForensicsPluginUiTest extends AbstractJUnitTest {
                 "Latest commit: 28af63d");
 
         assertThat(getSummaryText(build, MINER_ROW)).contains(
-                "SCM Statistics",
+                "SCM Forensics",
                 "51 repository files",
                 "total lines of code: 6066",
                 "total churn: 16966",


### PR DESCRIPTION
Some jobs are using multiple SCM repositories: one for the code, one for the pipeline library, etc. We need a way to select the correct repository for all features of the forensics API. See also [JENKINS-64578](https://issues.jenkins.io/browse/JENKINS-64578).
- [x] Add a test case that exposes the problem for the commit decorator
- [x] The commit recorder correctly scans both repositories
- [x] The commit decorator works only for the second one and points to the wrong repository
- [x] The reference build will also only use the first one
- [x] The miner does only scan the first one
- [x] The blamer does only work on the first one
- [x] Select existing miner results with the filter
