### PR TITLE
Do not add a new action if already attached by a parallel step

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -18,7 +18,7 @@
   <url>https://github.com/jenkinsci/git-forensics-plugin</url>
 
   <properties>
-    <revision>0.10.0</revision>
+    <revision>0.9.1</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <module.name>${project.groupId}.git.forensics</module.name>

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCheckoutListener.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCheckoutListener.java
@@ -80,7 +80,9 @@ public class GitCheckoutListener extends SCMListener {
 
         String latestRecordedCommit = getLatestRecordedCommit(build, id, logger);
         GitCommitsRecord commitsRecord = recordNewCommits(build, gitRepository, logger, latestRecordedCommit);
-        build.addAction(commitsRecord);
+        if (!hasRecordForScm(build, id)) { // In case a parallel step has added the same result in the meanwhile
+            build.addAction(commitsRecord);
+        }
     }
 
     private String getLatestRecordedCommit(final Run<?, ?> build, final String scmKey, final FilteredLog logger) {

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitCheckoutListenerITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitCheckoutListenerITest.java
@@ -136,6 +136,30 @@ public class GitCheckoutListenerITest extends IntegrationTestWithJenkinsPerSuite
         verifyAction(actions.get(1), GIT_FORENSICS_URL);
     }
 
+    /**
+     * Creates a pipeline that checks out the same repository twice.
+     */
+    @Test
+    public void shouldSkipDuplicateRepositories() {
+        WorkflowJob job = createPipeline();
+        job.setDefinition(asStage(
+                "checkout([$class: 'GitSCM', "
+                        + "branches: [[name: 'a6d0ef09ab3c418e370449a884da99b8190ae950' ]],\n"
+                        + "userRemoteConfigs: [[url: '" + FORENSICS_API_URL + "']],\n"
+                        + "extensions: [[$class: 'RelativeTargetDirectory', \n"
+                        + "            relativeTargetDir: 'forensics-api']]])",
+                "checkout([$class: 'GitSCM', "
+                        + "branches: [[name: 'a6d0ef09ab3c418e370449a884da99b8190ae950' ]],\n"
+                        + "userRemoteConfigs: [[url: '" + FORENSICS_API_URL + "']],\n"
+                        + "extensions: [[$class: 'RelativeTargetDirectory', \n"
+                        + "            relativeTargetDir: 'forensics-api']]])"));
+
+        List<GitCommitsRecord> actions = buildSuccessfully(job).getActions(GitCommitsRecord.class);
+        assertThat(actions).hasSize(1);
+
+        verifyAction(actions.get(0), FORENSICS_API_URL);
+    }
+
     private void verifyAction(final GitCommitsRecord record, final String repository) {
         assertThat(record.getInfoMessages())
                 .contains("Recording commits of 'git " + repository + "'",


### PR DESCRIPTION
Otherwise we get the same repository twice, see example build https://ci.jenkins.io/job/Plugins/job/analysis-model/job/master/1095/