### PR TITLE
Move repository browser commit link generation into git-plugin

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/util/GitCommitDecorator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/util/GitCommitDecorator.java
@@ -2,15 +2,10 @@ package io.jenkins.plugins.forensics.git.util;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.Collections;
-import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 
-import edu.hm.hafner.util.Generated;
-
-import hudson.plugins.git.GitChangeSet;
 import hudson.plugins.git.browser.GitRepositoryBrowser;
 import hudson.scm.RepositoryBrowser;
 
@@ -43,7 +38,7 @@ public class GitCommitDecorator extends GitCommitTextDecorator {
 
     private Optional<String> createLink(final String id) {
         try {
-            URL link = browser.getChangeSetLink(new DummyChangeSet(id));
+            URL link = browser.getChangeSetLink(id);
             if (link != null) {
                 return Optional.of(a().withText(asText(id)).withHref(link.toString()).render());
             }
@@ -52,40 +47,5 @@ public class GitCommitDecorator extends GitCommitTextDecorator {
             // ignore and return nothing
         }
         return Optional.empty();
-    }
-
-    // TODO: move this class and the implementation to the Git plugin
-    private static class DummyChangeSet extends GitChangeSet {
-        private final String id;
-
-        DummyChangeSet(final String id) {
-            super(Collections.emptyList(), false);
-            this.id = id;
-        }
-
-        @Override
-        public String getId() {
-            return id;
-        }
-
-        @Override @Generated
-        public boolean equals(final Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            if (!super.equals(o)) {
-                return false;
-            }
-            DummyChangeSet that = (DummyChangeSet) o;
-            return Objects.equals(id, that.id);
-        }
-
-        @Override @Generated
-        public int hashCode() {
-            return Objects.hash(super.hashCode(), id);
-        }
     }
 }


### PR DESCRIPTION
Creation of commit links currently is done in the git-forensics plugin by accessing some internal API methods. It makes much more sense to move these methods to the git plugin itself. 

This PR depends on jenkinsci/git-plugin#1034 which has been released in [git-4.10.0](https://github.com/jenkinsci/git-plugin/releases/tag/git-4.10.0).

