### PR TITLE
Add delta forensics for PR and branch builds

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -27,7 +27,7 @@
     <eclipse-collections.version>9.2.0</eclipse-collections.version>
 
     <!-- Jenkins Plugin Dependencies Versions -->
-    <forensics-api-plugin.version>1.2.0-rc921.58150b80d4d0</forensics-api-plugin.version>
+    <forensics-api-plugin.version>1.2.0-rc925.570ee9c542e0</forensics-api-plugin.version>
     <plugin-util-api.version>2.3.0</plugin-util-api.version>
     <data-tables-api.version>1.10.25-1</data-tables-api.version>
     <jquery3-api.version>3.6.0-1</jquery3-api.version>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -27,14 +27,13 @@
     <eclipse-collections.version>9.2.0</eclipse-collections.version>
 
     <!-- Jenkins Plugin Dependencies Versions -->
-    <forensics-api-plugin.version>1.0.0</forensics-api-plugin.version>
+    <forensics-api-plugin.version>1.2.0-rc921.58150b80d4d0</forensics-api-plugin.version>
     <plugin-util-api.version>2.3.0</plugin-util-api.version>
-    <data-tables-api.version>1.10.23-3</data-tables-api.version>
-    <echarts-api.version>5.1.0-2</echarts-api.version>
-    <popper-api.version>1.16.1-2</popper-api.version>
+    <data-tables-api.version>1.10.25-1</data-tables-api.version>
     <jquery3-api.version>3.6.0-1</jquery3-api.version>
-    <bootstrap4-api.version>4.6.0-3</bootstrap4-api.version>
     <font-awesome-api.version>5.15.3-3</font-awesome-api.version>
+    <echarts-api.version>5.1.2-2</echarts-api.version>
+    <bootstrap5-api.version>5.0.1-2</bootstrap5-api.version>
 
     <git-plugin.version>4.6.0</git-plugin.version>
     <git-client.version>3.6.0</git-client.version>
@@ -42,9 +41,6 @@
 
     <j2html.version>1.4.0</j2html.version>
     <streamex.version>0.7.3</streamex.version>
-
-    <bootstrap4-api.version>4.6.0-2</bootstrap4-api.version>
-    <font-awesome-api.version>5.15.2-2</font-awesome-api.version>
   </properties>
 
   <licenses>
@@ -86,18 +82,13 @@
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
-        <artifactId>bootstrap4-api</artifactId>
-        <version>${bootstrap4-api.version}</version>
+        <artifactId>bootstrap5-api</artifactId>
+        <version>${bootstrap5-api.version}</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>font-awesome-api</artifactId>
         <version>${font-awesome-api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>popper-api</artifactId>
-        <version>${popper-api.version}</version>
       </dependency>
       <dependency>
         <groupId>io.jenkins.plugins</groupId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -18,7 +18,7 @@
   <url>https://github.com/jenkinsci/git-forensics-plugin</url>
 
   <properties>
-    <revision>1.0.1</revision>
+    <revision>1.1.0</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <module.name>${project.groupId}.git.forensics</module.name>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -27,7 +27,7 @@
     <eclipse-collections.version>9.2.0</eclipse-collections.version>
 
     <!-- Jenkins Plugin Dependencies Versions -->
-    <forensics-api-plugin.version>1.2.0-rc925.570ee9c542e0</forensics-api-plugin.version>
+    <forensics-api-plugin.version>1.2.0</forensics-api-plugin.version>
     <plugin-util-api.version>2.3.0</plugin-util-api.version>
     <data-tables-api.version>1.10.25-1</data-tables-api.version>
     <jquery3-api.version>3.6.0-1</jquery3-api.version>

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/CommitStatisticsStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/CommitStatisticsStep.java
@@ -57,7 +57,7 @@ import io.jenkins.plugins.util.LogHandler;
  *
  * @author Ullrich Hafner
  */
-@SuppressWarnings("checkstyle:ClassFanOutComplexity")
+@SuppressWarnings({"checkstyle:ClassFanOutComplexity", "PMD.ExcessiveImports"})
 public class CommitStatisticsStep extends Recorder implements SimpleBuildStep {
     private static final GitCommitTextDecorator RENDERER = new GitCommitTextDecorator();
 

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/CommitStatisticsStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/CommitStatisticsStep.java
@@ -1,0 +1,183 @@
+package io.jenkins.plugins.forensics.git.miner;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+
+import edu.hm.hafner.util.FilteredLog;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.AbstractProject;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.scm.SCM;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Publisher;
+import hudson.tasks.Recorder;
+import jenkins.tasks.SimpleBuildStep;
+
+import io.jenkins.plugins.forensics.git.reference.GitCommitsRecord;
+import io.jenkins.plugins.forensics.git.util.GitRepositoryValidator;
+import io.jenkins.plugins.forensics.git.util.RemoteResultWrapper;
+import io.jenkins.plugins.forensics.miner.CommitDiffItem;
+import io.jenkins.plugins.forensics.miner.CommitStatistics;
+import io.jenkins.plugins.forensics.miner.CommitStatisticsBuildAction;
+import io.jenkins.plugins.forensics.miner.ForensicsBuildAction;
+import io.jenkins.plugins.forensics.miner.RepositoryStatistics;
+import io.jenkins.plugins.forensics.reference.ReferenceFinder;
+import io.jenkins.plugins.forensics.util.ScmResolver;
+import io.jenkins.plugins.util.LogHandler;
+
+/**
+ * A pipeline {@link Step} or Freestyle or Maven {@link Recorder} that obtains statistics for all repository files. The
+ * following statistics are computed:
+ * <ul>
+ *     <li>total number of commits</li>
+ *     <li>total number of different authors</li>
+ *     <li>creation time</li>
+ *     <li>last modification time</li>
+ *     <li>lines of code (from the commit details)</li>
+ *     <li>code churn (changed lines since created)</li>
+ * </ul>
+ * Stores the created statistics in a {@link RepositoryStatistics} instance. The result is attached to
+ * a {@link Run} by registering a {@link ForensicsBuildAction}.
+ *
+ * @author Ullrich Hafner
+ */
+public class CommitStatisticsStep extends Recorder implements SimpleBuildStep {
+    private String scm = StringUtils.EMPTY;
+
+    /**
+     * Creates a new instance of {@link  CommitStatisticsStep}.
+     */
+    @DataBoundConstructor
+    public CommitStatisticsStep() {
+        super();
+
+        // empty constructor required for Stapler
+    }
+
+    /**
+     * Sets the SCM that should be used to find the reference build for. The reference recorder will select the SCM
+     * based on a substring comparison, there is no need to specify the full name.
+     *
+     * @param scm
+     *         the ID of the SCM to use (a substring of the full ID)
+     */
+    @DataBoundSetter
+    public void setScm(final String scm) {
+        this.scm = scm;
+    }
+
+    public String getScm() {
+        return scm;
+    }
+
+    @Override
+    public void perform(@NonNull final Run<?, ?> run, @NonNull final FilePath workspace, @NonNull final EnvVars env,
+            @NonNull final Launcher launcher, @NonNull final TaskListener listener) throws InterruptedException {
+        LogHandler logHandler = new LogHandler(listener, "Git DiffStats");
+        FilteredLog logger = new FilteredLog("Errors while computing diff statistics");
+
+        Optional<Run<?, ?>> possibleReferenceBuild = new ReferenceFinder().findReference(run, logger);
+        if (possibleReferenceBuild.isPresent()) {
+            Run<?, ?> referenceBuild = possibleReferenceBuild.get();
+            logger.logInfo("Analyzing commits to obtain diff statistics for affected repository files");
+            logger.logInfo("-> using reference build '%s' as target branch", referenceBuild);
+            analyzeRepositories(run, workspace, referenceBuild, listener, logger, logHandler);
+        }
+        else {
+            logger.logInfo("Skipping commit statistics step since no reference build has been found");
+        }
+    }
+
+    private void analyzeRepositories(final Run<?, ?> run, final FilePath workspace, final Run<?, ?> referenceBuild,
+            final TaskListener listener, final FilteredLog logger, final LogHandler logHandler)
+            throws InterruptedException {
+        for (SCM repository : new ScmResolver().getScms(run, getScm())) {
+            logger.logInfo("-> checking SCM '%s'", repository.getKey());
+            logHandler.log(logger);
+
+            GitRepositoryValidator validator = new GitRepositoryValidator(
+                    repository, run, workspace, listener, logger);
+            if (validator.isGitRepository()) {
+                attachStatisticsAction(run, repository, validator.createClient(), referenceBuild, logger);
+            }
+            else {
+                logger.logInfo("-> skipping not supported repository");
+            }
+
+            logHandler.log(logger);
+        }
+    }
+
+    private void attachStatisticsAction(final Run<?, ?> run, final SCM repository, final GitClient gitClient,
+            final Run<?, ?> referenceBuild, final FilteredLog logger) throws InterruptedException {
+        logger.logInfo("-> found a supported Git repository: %s", repository.getKey());
+
+        GitCommitsRecord commitsRecord = referenceBuild.getAction(GitCommitsRecord.class);
+        if (commitsRecord == null) {
+            logger.logInfo("-> skipping since reference build '%s' has no recorded commits", referenceBuild);
+        }
+        else {
+            String latestCommit = commitsRecord.getLatestCommit();
+            try {
+                String ancestor = gitClient.withRepository(new MergeBaseSelector(latestCommit));
+                if (StringUtils.isNotEmpty(ancestor)) {
+                    logger.logInfo("-> selecting common ancestor '%s' of reference build '%s'", ancestor,
+                            referenceBuild);
+                    RemoteResultWrapper<ArrayList<CommitDiffItem>> wrapped = gitClient.withRepository(
+                            new RepositoryStatisticsCallback(ancestor));
+                    List<CommitDiffItem> commits = wrapped.getResult();
+                    CommitStatistics.logCommits(commits, logger);
+
+                    RepositoryStatistics repositoryStatistics = new RepositoryStatistics(ancestor);
+                    repositoryStatistics.addAll(commits);
+                    run.addAction(new CommitStatisticsBuildAction(run, repository.getKey(),
+                            repositoryStatistics.getLatestStatistics()));
+                }
+                else {
+                    logger.logInfo("-> No common ancestor for reference build '%s' found", referenceBuild);
+                }
+            }
+            catch (IOException exception) {
+                logger.logInfo("-> No common ancestor for reference build '%s' found: %s", referenceBuild, exception);
+            }
+        }
+    }
+
+    @Override
+    public Descriptor getDescriptor() {
+        return (Descriptor) super.getDescriptor();
+    }
+
+    /**
+     * Descriptor for this step: defines the context and the UI elements.
+     */
+    @Extension
+    @Symbol("gitDiffStat")
+    public static class Descriptor extends BuildStepDescriptor<Publisher> {
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return "Git Diff Statistics";
+        }
+
+        @Override
+        public boolean isApplicable(final Class<? extends AbstractProject> jobType) {
+            return true;
+        }
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/GitRepositoryMiner.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/GitRepositoryMiner.java
@@ -5,15 +5,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
-
 import edu.hm.hafner.util.FilteredLog;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import org.jenkinsci.plugins.gitclient.GitClient;
-import hudson.model.Run;
 
-import io.jenkins.plugins.forensics.git.reference.GitCommitsRecord;
 import io.jenkins.plugins.forensics.git.util.RemoteResultWrapper;
 import io.jenkins.plugins.forensics.miner.CommitDiffItem;
 import io.jenkins.plugins.forensics.miner.CommitStatistics;

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/GitRepositoryMiner.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/GitRepositoryMiner.java
@@ -5,16 +5,25 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.revwalk.filter.RevFilter;
 
 import edu.hm.hafner.util.FilteredLog;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import org.jenkinsci.plugins.gitclient.GitClient;
+import org.jenkinsci.plugins.gitclient.RepositoryCallback;
+import hudson.model.Run;
 import hudson.remoting.VirtualChannel;
 
+import io.jenkins.plugins.forensics.git.reference.GitCommitsRecord;
 import io.jenkins.plugins.forensics.git.util.AbstractRepositoryCallback;
 import io.jenkins.plugins.forensics.git.util.RemoteResultWrapper;
 import io.jenkins.plugins.forensics.miner.CommitDiffItem;
@@ -41,6 +50,31 @@ public class GitRepositoryMiner extends RepositoryMiner {
         super();
 
         this.gitClient = gitClient;
+    }
+
+    @Override
+    public RepositoryStatistics mine(final Run<?, ?> build, final FilteredLog logger) throws InterruptedException {
+        GitCommitsRecord commitsRecord = build.getAction(GitCommitsRecord.class);
+        if (commitsRecord == null) {
+            logger.logInfo("Skipping delta mining since reference build '%s' has no recorded commits", build);
+        }
+        else {
+            logger.logInfo("Starting delta mining of commits");
+            String latestCommit = commitsRecord.getLatestCommit();
+            try {
+                String ancestor = gitClient.withRepository(new MergeBaseSelector(latestCommit));
+                if (StringUtils.isNotEmpty(ancestor)) {
+                    logger.logInfo("-> Selecting common ancestor '%s' of reference build '%s'", ancestor, build);
+
+                    return mine(new RepositoryStatistics(ancestor), logger);
+                }
+                logger.logInfo("-> No common ancestor for reference build '%s' found", build);
+            }
+            catch (IOException exception) {
+                logger.logInfo("-> No common ancestor for reference build '%s' found: %s", build, exception);
+            }
+        }
+        return new RepositoryStatistics();
     }
 
     // TODO: we need to create the new results separately to compute the added and deleted lines per build
@@ -91,7 +125,8 @@ public class GitRepositoryMiner extends RepositoryMiner {
             this.previousCommitId = previousCommitId;
         }
 
-        @Override @SuppressWarnings("PMD.UseTryWithResources")
+        @Override
+        @SuppressWarnings("PMD.UseTryWithResources")
         public RemoteResultWrapper<ArrayList<CommitDiffItem>> invoke(
                 final Repository repository, final VirtualChannel channel) {
             ArrayList<CommitDiffItem> commits = new ArrayList<>();
@@ -113,6 +148,43 @@ public class GitRepositoryMiner extends RepositoryMiner {
             }
 
             return wrapper;
+        }
+    }
+
+    /**
+     * Finds as good common ancestors as possible for a merge.
+     *
+     * @author Ullrich Hafner
+     * @see <a href="https://git-scm.com/docs/git-merge-base">Git git-merge-base command</a>
+     */
+    private static class MergeBaseSelector implements RepositoryCallback<String> {
+        private static final long serialVersionUID = 163631519980916591L;
+
+        private final String latestCommit;
+
+        MergeBaseSelector(final String latestCommit) {
+            this.latestCommit = latestCommit;
+        }
+
+        @Override
+        public String invoke(final Repository repository, final VirtualChannel virtualChannel) throws IOException {
+            ObjectId head = repository.resolve(Constants.HEAD);
+            if (head == null) {
+                return "";
+            }
+
+            ObjectId target = repository.resolve(latestCommit);
+
+            RevWalk walk = new RevWalk(repository);
+            walk.setRevFilter(RevFilter.MERGE_BASE);
+            walk.markStart(repository.parseCommit(target));
+            walk.markStart(repository.parseCommit(head));
+
+            RevCommit next = walk.next();
+            if (next == null) {
+                return latestCommit;
+            }
+            return next.getId().getName();
         }
     }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/MergeBaseSelector.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/MergeBaseSelector.java
@@ -1,0 +1,50 @@
+package io.jenkins.plugins.forensics.git.miner;
+
+import java.io.IOException;
+
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.revwalk.filter.RevFilter;
+
+import org.jenkinsci.plugins.gitclient.RepositoryCallback;
+import hudson.remoting.VirtualChannel;
+
+/**
+ * Finds as good common ancestors as possible for a merge.
+ *
+ * @author Ullrich Hafner
+ * @see <a href="https://git-scm.com/docs/git-merge-base">Git git-merge-base command</a>
+ */
+class MergeBaseSelector implements RepositoryCallback<String> {
+    private static final long serialVersionUID = 163631519980916591L;
+
+    private final String latestCommit;
+
+    MergeBaseSelector(final String latestCommit) {
+        this.latestCommit = latestCommit;
+    }
+
+    @Override
+    public String invoke(final Repository repository, final VirtualChannel virtualChannel) throws IOException {
+        ObjectId head = repository.resolve(Constants.HEAD);
+        if (head == null) {
+            return "";
+        }
+
+        ObjectId target = repository.resolve(latestCommit);
+
+        RevWalk walk = new RevWalk(repository);
+        walk.setRevFilter(RevFilter.MERGE_BASE);
+        walk.markStart(repository.parseCommit(target));
+        walk.markStart(repository.parseCommit(head));
+
+        RevCommit next = walk.next();
+        if (next == null) {
+            return latestCommit;
+        }
+        return next.getId().getName();
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/RepositoryStatisticsCallback.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/RepositoryStatisticsCallback.java
@@ -1,0 +1,58 @@
+package io.jenkins.plugins.forensics.git.miner;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Repository;
+
+import hudson.remoting.VirtualChannel;
+
+import io.jenkins.plugins.forensics.git.util.AbstractRepositoryCallback;
+import io.jenkins.plugins.forensics.git.util.RemoteResultWrapper;
+import io.jenkins.plugins.forensics.miner.CommitDiffItem;
+
+/**
+ * Analyzes all commits starting from HEAD up to a specified commit ID. If no previous commit ID is given,
+ * then the repository will be scanned until the initial commit is reached.
+ *
+ * @author Ullrich Hafner
+ */
+class RepositoryStatisticsCallback
+        extends AbstractRepositoryCallback<RemoteResultWrapper<ArrayList<CommitDiffItem>>> {
+    private static final long serialVersionUID = 7667073858514128136L;
+
+    private final String previousCommitId;
+
+    RepositoryStatisticsCallback(final String previousCommitId) {
+        super();
+
+        this.previousCommitId = previousCommitId;
+    }
+
+    @Override
+    @SuppressWarnings("PMD.UseTryWithResources")
+    public RemoteResultWrapper<ArrayList<CommitDiffItem>> invoke(
+            final Repository repository, final VirtualChannel channel) {
+        ArrayList<CommitDiffItem> commits = new ArrayList<>();
+        RemoteResultWrapper<ArrayList<CommitDiffItem>> wrapper = new RemoteResultWrapper<>(
+                commits, "Errors while mining the Git repository:");
+
+        try {
+            try (Git git = new Git(repository)) {
+                CommitAnalyzer commitAnalyzer = new CommitAnalyzer();
+                commits.addAll(commitAnalyzer.run(repository, git, previousCommitId, wrapper));
+            }
+            catch (IOException | GitAPIException exception) {
+                wrapper.logException(exception,
+                        "Can't analyze commits for the repository " + repository.getIdentifier());
+            }
+        }
+        finally {
+            repository.close();
+        }
+
+        return wrapper;
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/util/GitCommitTextDecorator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/util/GitCommitTextDecorator.java
@@ -9,7 +9,7 @@ import io.jenkins.plugins.forensics.util.CommitDecorator;
  *
  * @author Ullrich Hafner
  */
-class GitCommitTextDecorator extends CommitDecorator {
+public class GitCommitTextDecorator extends CommitDecorator {
     @Override
     public String asLink(final String id) {
         return asText(id);

--- a/plugin/src/main/webapp/icons/LICENSE.txt
+++ b/plugin/src/main/webapp/icons/LICENSE.txt
@@ -1,0 +1,4 @@
+License for FontAwesome icon: CC BY 4.0 License
+https://fontawesome.com/license/free
+
+

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderITest.java
@@ -111,7 +111,7 @@ public class GitReferenceRecorderITest extends GitITest {
                 .hasCommitCount(1)
                 .hasFilesCount(1)
                 .hasAddedLines(1)
-                .hasDeletedLines(1);
+                .hasDeletedLines(0);
     }
 
     private CommitStatistics getCommitStatisticsOf(final WorkflowRun lastBuild) {

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderITest.java
@@ -26,6 +26,7 @@ import jenkins.plugins.git.GitSCMSource;
 import jenkins.scm.api.SCMSource;
 
 import io.jenkins.plugins.forensics.git.util.GitITest;
+import io.jenkins.plugins.forensics.miner.ForensicsBuildAction;
 import io.jenkins.plugins.forensics.reference.ReferenceBuild;
 
 import static io.jenkins.plugins.forensics.assertions.Assertions.*;
@@ -98,9 +99,18 @@ public class GitReferenceRecorderITest extends GitITest {
 
         WorkflowJob featureBranch = createPipeline("feature");
         featureBranch.setDefinition(asStage(createLocalGitCheckout("feature"),
-                "discoverGitReferenceBuild(referenceJob: 'main')"));
+                "discoverGitReferenceBuild(referenceJob: 'main')",
+                "mineRepository()"));
 
         verifyPipelineResult(masterBuild, featureBranch);
+
+        ForensicsBuildAction action = featureBranch.getLastBuild().getAction(ForensicsBuildAction.class);
+        assertThat(action.getNumberOfFiles()).isEqualTo(1);
+        assertThat(action.getTotalChurn()).isEqualTo(1);
+        assertThat(action.getTotalLinesOfCode()).isEqualTo(1);
+        assertThat(action.getDeltaNumberOfFiles()).isEqualTo(1);
+        assertThat(action.getDeltaTotalChurn()).isEqualTo(1);
+        assertThat(action.getDeltaTotalLinesOfCode()).isEqualTo(1);
     }
 
     /**
@@ -295,6 +305,17 @@ public class GitReferenceRecorderITest extends GitITest {
                 .hasOwner(featureBuild)
                 .hasReferenceBuildId(masterBuild.getExternalizableId())
                 .hasReferenceBuild(Optional.of(masterBuild));
+
+        ForensicsBuildAction action = featureBuild.getAction(ForensicsBuildAction.class);
+        assertThat(action.getNumberOfFiles()).isEqualTo(2);
+        assertThat(action.getTotalChurn()).isEqualTo(6);
+        assertThat(action.getTotalLinesOfCode()).isEqualTo(2);
+        assertThat(action.getCommitStatistics().getCommitCount()).isEqualTo(3);
+
+        assertThat(action.getDeltaNumberOfFiles()).isEqualTo(2);
+        assertThat(action.getDeltaTotalChurn()).isEqualTo(4);
+        assertThat(action.getDeltaTotalLinesOfCode()).isEqualTo(0);
+        assertThat(action.getDeltaCommitStatistics().getCommitCount()).isEqualTo(1);
     }
 
     /**
@@ -593,7 +614,8 @@ public class GitReferenceRecorderITest extends GitITest {
             writeFile(JENKINS_FILE, "echo \"branch=${env.BRANCH_NAME}\"; "
                     + "node {checkout scm; echo readFile('file'); "
                     + "echo \"GitForensics\"; "
-                    + "discoverGitReferenceBuild()}");
+                    + "discoverGitReferenceBuild();"
+                    + "mineRepository()}");
             writeFile(SOURCE_FILE, "master content");
             addFile(JENKINS_FILE);
             commit("initial content");
@@ -616,7 +638,8 @@ public class GitReferenceRecorderITest extends GitITest {
                     String.format("echo \"branch=${env.BRANCH_NAME}\";"
                             + "node {checkout scm; echo readFile('file').toUpperCase(); "
                             + "echo \"GitForensics\"; "
-                            + "discoverGitReferenceBuild(%s)}", String.join(",", parameters)));
+                            + "discoverGitReferenceBuild(%s);"
+                            + "mineRepository()}", String.join(",", parameters)));
             writeFile(SOURCE_FILE, branch + " content");
             commit(branch + " changes");
         }

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderITest.java
@@ -107,11 +107,15 @@ public class GitReferenceRecorderITest extends GitITest {
 
         verifyPipelineResult(masterBuild, featureBranch);
 
-        CommitStatistics action = featureBranch.getLastBuild().getAction(CommitStatisticsBuildAction.class).getCommitStatistics();
-        assertThat(action.getCommitCount()).isEqualTo(1);
-        assertThat(action.getFilesCount()).isEqualTo(1);
-        assertThat(action.getAddedLines()).isEqualTo(1);
-        assertThat(action.getDeletedLines()).isEqualTo(0);
+        assertThat(getCommitStatisticsOf(featureBranch.getLastBuild()))
+                .hasCommitCount(1)
+                .hasFilesCount(1)
+                .hasAddedLines(1)
+                .hasDeletedLines(1);
+    }
+
+    private CommitStatistics getCommitStatisticsOf(final WorkflowRun lastBuild) {
+        return lastBuild.getAction(CommitStatisticsBuildAction.class).getCommitStatistics();
     }
 
     /**
@@ -307,11 +311,11 @@ public class GitReferenceRecorderITest extends GitITest {
                 .hasReferenceBuildId(masterBuild.getExternalizableId())
                 .hasReferenceBuild(Optional.of(masterBuild));
 
-        CommitStatistics action = featureBuild.getAction(CommitStatisticsBuildAction.class).getCommitStatistics();
-        assertThat(action.getCommitCount()).isEqualTo(1);
-        assertThat(action.getFilesCount()).isEqualTo(2);
-        assertThat(action.getDeletedLines()).isEqualTo(2);
-        assertThat(action.getAddedLines()).isEqualTo(2);
+        assertThat(getCommitStatisticsOf(featureBuild))
+                .hasCommitCount(1)
+                .hasFilesCount(2)
+                .hasAddedLines(2)
+                .hasDeletedLines(2);
     }
 
     /**
@@ -346,6 +350,12 @@ public class GitReferenceRecorderITest extends GitITest {
         WorkflowRun firstFeature = verifyFeatureBuild(project, 1);
         verifyRecordSize(firstFeature, 4);
 
+        assertThat(getCommitStatisticsOf(firstFeature))
+                .hasCommitCount(2)
+                .hasFilesCount(3)
+                .hasAddedLines(3)
+                .hasDeletedLines(2);
+
         assertThat(firstFeature.getAction(ReferenceBuild.class)).as(getLog(firstFeature)).isNotNull()
                 .hasOwner(firstFeature); // we do not care about the reference of the first feature build
 
@@ -359,6 +369,12 @@ public class GitReferenceRecorderITest extends GitITest {
                 .hasOwner(featureBuild)
                 .hasReferenceBuildId(nextMaster.getExternalizableId())
                 .hasReferenceBuild(Optional.of(nextMaster));
+
+        assertThat(getCommitStatisticsOf(featureBuild))
+                .hasCommitCount(3)
+                .hasFilesCount(3)
+                .hasAddedLines(4)
+                .hasDeletedLines(3);
     }
 
     /**
@@ -470,6 +486,12 @@ public class GitReferenceRecorderITest extends GitITest {
                 .hasOwner(featureBuild)
                 .hasReferenceBuildId(nextMaster.getExternalizableId())
                 .hasReferenceBuild(Optional.of(nextMaster));
+
+        assertThat(getCommitStatisticsOf(featureBuild))
+                .hasCommitCount(4)
+                .hasFilesCount(3)
+                .hasAddedLines(6)
+                .hasDeletedLines(3);
     }
 
     /**

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderITest.java
@@ -28,7 +28,6 @@ import jenkins.scm.api.SCMSource;
 import io.jenkins.plugins.forensics.git.util.GitITest;
 import io.jenkins.plugins.forensics.miner.CommitStatistics;
 import io.jenkins.plugins.forensics.miner.CommitStatisticsBuildAction;
-import io.jenkins.plugins.forensics.miner.ForensicsBuildAction;
 import io.jenkins.plugins.forensics.reference.ReferenceBuild;
 
 import static io.jenkins.plugins.forensics.assertions.Assertions.*;

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/util/GitITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/util/GitITest.java
@@ -51,6 +51,9 @@ public class GitITest extends IntegrationTestWithJenkinsPerTest {
     /** Author 2 email. */
     protected static final String BAR_EMAIL = "bar@jenkins.io";
 
+    /** Initial branch used in Git repository. */
+    protected static final String INITIAL_BRANCH = "main";
+
     /** Git repository in a temporary folder. */
     @Rule
     public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
@@ -64,6 +67,7 @@ public class GitITest extends IntegrationTestWithJenkinsPerTest {
     @Before
     public void init() throws Exception {
         sampleRepo.init();
+        checkoutNewBranch(INITIAL_BRANCH);
     }
 
     /**
@@ -138,7 +142,7 @@ public class GitITest extends IntegrationTestWithJenkinsPerTest {
 
     protected void checkoutNewBranch(final String branch) {
         try {
-            sampleRepo.git("checkout", "-b", branch);
+            sampleRepo.git("switch", "-C", branch);
         }
         catch (Exception exception) {
             throw new AssertionError(exception);

--- a/plugin/src/test/resources/design.puml
+++ b/plugin/src/test/resources/design.puml
@@ -14,6 +14,7 @@ skinparam component {
 
 [Blamer] --> [Utilities]
 [Miner] --> [Utilities]
+[Miner] -> [Reference]
 [Reference] --> [Utilities]
 
 @enduml

--- a/ui-tests/src/test/java/io/jenkins/plugins/forensics/ForensicsPluginUiTest.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/forensics/ForensicsPluginUiTest.java
@@ -51,8 +51,8 @@ public class ForensicsPluginUiTest extends AbstractJUnitTest {
                 "Latest commit: 28af63d");
 
         assertThat(getSummaryText(build, MINER_ROW)).contains(
-                "New commits since previous build: 402",
-                "from 4 authors",
+                "New commits: 402",
+                "4 authors",
                 "131 files",
                 "16510 added",
                 "10444 deleted");

--- a/ui-tests/src/test/java/io/jenkins/plugins/forensics/ForensicsPluginUiTest.java
+++ b/ui-tests/src/test/java/io/jenkins/plugins/forensics/ForensicsPluginUiTest.java
@@ -51,15 +51,11 @@ public class ForensicsPluginUiTest extends AbstractJUnitTest {
                 "Latest commit: 28af63d");
 
         assertThat(getSummaryText(build, MINER_ROW)).contains(
-                "SCM Forensics",
-                "51 repository files",
-                "total lines of code: 6066",
-                "total churn: 16966",
-                "New added lines: 16510",
-                "New deleted lines: 10444",
-                "New commits: 402",
+                "New commits since previous build: 402",
                 "from 4 authors",
-                "in 131 files");
+                "131 files",
+                "16510 added",
+                "10444 deleted");
 
         ScmForensics scmForensics = new ScmForensics(build, "forensics");
         scmForensics.open();


### PR DESCRIPTION
Currently the repository miner creates statistics for the whole repository only. In order to compute delta statistics for pull requests (and branches) an additional miner step has been added.

Downstream PR of jenkinsci/forensics-api-plugin#293