### PR TITLE
Bump credentials from 2.4.1 to 2.5

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -34,6 +34,7 @@
     <font-awesome-api.version>5.15.3-3</font-awesome-api.version>
     <echarts-api.version>5.1.2-2</echarts-api.version>
     <bootstrap5-api.version>5.0.1-2</bootstrap5-api.version>
+    <credentials.version>2.5</credentials.version>
 
     <git-plugin.version>4.6.0</git-plugin.version>
     <git-client.version>3.6.0</git-client.version>
@@ -68,7 +69,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>credentials</artifactId>
-        <version>2.4.1</version>
+        <version>${credentials.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Bump credentials from 2.4.1 to 2.5 to resolve issue with #306 and the other dependencies.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
