### PR TITLE
Add special handling for PR builds

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -143,6 +143,10 @@
       <artifactId>plugin-util-api</artifactId>
       <version>${plugin-util-api.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>branch-api</artifactId>
+    </dependency>
 
     <!-- Test Dependencies -->
     <dependency>

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/blame/package-info.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/blame/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Provides classes to run `git blame`. Using this service, plugins can show in which Git revisions the lines of a file
+ * have been modified by what authors. This information can be used to discover the original commit that is the origin
+ * for a piece of problematic code.
+ */
+@DefaultAnnotation(NonNull.class)
+package io.jenkins.plugins.forensics.git.blame;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/CommitAnalyzer.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/CommitAnalyzer.java
@@ -22,7 +22,6 @@ import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.TreeStringBuilder;
 
 import io.jenkins.plugins.forensics.miner.CommitDiffItem;
-import io.jenkins.plugins.forensics.miner.CommitStatistics;
 
 /**
  * Analyzes the new Git repository commits since a previous commit ID and and creates {@link CommitDiffItem} instances for all
@@ -32,8 +31,6 @@ import io.jenkins.plugins.forensics.miner.CommitStatistics;
  * @author Ullrich Hafner
  */
 class CommitAnalyzer {
-    private static final int MAX_COMMIT_TO_LOG = 7;
-
     List<CommitDiffItem> run(final Repository repository, final Git git,
             final String latestCommitOfPreviousBuild,
             final FilteredLog logger) throws IOException, GitAPIException {
@@ -42,9 +39,7 @@ class CommitAnalyzer {
         if (newRevCommits.isEmpty()) {
             logger.logInfo("No commits found since previous commit '%s'", latestCommitOfPreviousBuild);
         }
-        if (newRevCommits.size() >= MAX_COMMIT_TO_LOG) {
-            logger.logInfo("Found %d commits", newRevCommits.size());
-        }
+        logger.logInfo("Found %d commits", newRevCommits.size());
 
         TreeStringBuilder fileNameBuilder = new TreeStringBuilder();
         List<CommitDiffItem> commitsOfBuild = new ArrayList<>();
@@ -52,14 +47,8 @@ class CommitAnalyzer {
             AbstractTreeIterator toTree = createTreeIteratorToCompareTo(
                     repository, newRevCommits, i, latestCommitOfPreviousBuild, logger);
             CommitDiffItem commit = createFromRevCommit(newRevCommits.get(i));
-            List<CommitDiffItem> commits = new DiffsCollector().getDiffsForCommit(repository, git, commit, toTree,
-                    fileNameBuilder, logger);
-            if (newRevCommits.size() < MAX_COMMIT_TO_LOG) {
-                logger.logInfo("Analyzed commit '%s' (authored by %s): %d files affected",
-                        commit.getId(), commit.getAuthor(), commits.size());
-                CommitStatistics.logCommits(commits, logger);
-            }
-            commitsOfBuild.addAll(commits);
+            commitsOfBuild.addAll(new DiffsCollector().getDiffsForCommit(
+                    repository, git, commit, toTree, fileNameBuilder, logger));
         }
         fileNameBuilder.dedup();
 

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/CommitAnalyzer.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/CommitAnalyzer.java
@@ -24,7 +24,7 @@ import edu.hm.hafner.util.TreeStringBuilder;
 import io.jenkins.plugins.forensics.miner.CommitDiffItem;
 
 /**
- * Analyzes the new Git repository commits since a previous commit ID and and creates {@link CommitDiffItem} instances for all
+ * Analyzes the new Git repository commits since a previous commit ID and creates {@link CommitDiffItem} instances for all
  * changes.
  *
  * @author Giulia Del Bravo
@@ -73,8 +73,7 @@ class CommitAnalyzer {
 
     private AbstractTreeIterator createTreeIteratorToCompareTo(final Repository repository,
             final List<RevCommit> newCommits, final int index, final String latestCommitOfPreviousBuild,
-            final FilteredLog logger)
-            throws IOException {
+            final FilteredLog logger) throws IOException {
         int compareIndex = index + 1;
         if (compareIndex < newCommits.size()) { // compare with another commit in the list
             return createTreeIteratorFor(newCommits.get(compareIndex).getName(), repository, logger);
@@ -86,8 +85,7 @@ class CommitAnalyzer {
     }
 
     static AbstractTreeIterator createTreeIteratorFor(final String commitId, final Repository repository,
-            final FilteredLog logger)
-            throws IOException {
+            final FilteredLog logger) throws IOException {
         try (RevWalk walk = new RevWalk(repository)) {
             ObjectId resolve = repository.resolve(commitId);
             if (resolve == null) {

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/CommitCollector.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/CommitCollector.java
@@ -18,15 +18,14 @@ import one.util.streamex.StreamEx;
 
 /**
  * Collects all commits for a git repository up to a given commit ID. The collected commits will be sorted ascending,
- * i.e. the list starts with the the given commit ID up to the current HEAD.
+ * i.e. the list starts with the given commit ID up to the current HEAD.
  *
  * @author Giulia Del Bravo
  * @author Ullrich Hafner
  */
 class CommitCollector {
     List<RevCommit> findAllCommits(final Repository repository, final Git git, final String latestCommitId,
-            final FilteredLog logger)
-            throws IOException, GitAPIException {
+            final FilteredLog logger) throws IOException, GitAPIException {
         ObjectId head = repository.resolve(Constants.HEAD);
         if (head == null) {
             logger.logError("No HEAD commit found in " + repository);

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/CommitStatisticsStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/CommitStatisticsStep.java
@@ -124,12 +124,12 @@ public class CommitStatisticsStep extends Recorder implements SimpleBuildStep {
         if (possibleReferenceBuild.isPresent()) {
             Run<?, ?> referenceBuild = possibleReferenceBuild.get();
             logger.logInfo("-> found reference build '%s'", referenceBuild);
-            GitCommitsRecord commitsRecord = referenceBuild.getAction(GitCommitsRecord.class);
-            if (commitsRecord == null) {
+            GitCommitsRecord referenceCommits = referenceBuild.getAction(GitCommitsRecord.class);
+            if (referenceCommits == null) {
                 logger.logInfo("-> skipping since reference build '%s' has no recorded commits", referenceBuild);
             }
             else {
-                computeStatsBasedOnReferenceBuild(run, logger, repository, validator, commitsRecord);
+                computeStatsBasedOnReferenceBuild(run, logger, repository, validator, referenceCommits);
             }
         }
         else {
@@ -144,9 +144,9 @@ public class CommitStatisticsStep extends Recorder implements SimpleBuildStep {
     }
 
     private void computeStatsBasedOnReferenceBuild(final Run<?, ?> run, final FilteredLog logger, final SCM repository,
-            final GitRepositoryValidator validator, final GitCommitsRecord commitsRecord)
+            final GitRepositoryValidator validator, final GitCommitsRecord referenceCommits)
             throws IOException, InterruptedException {
-        String latestCommit = commitsRecord.getLatestCommit();
+        String latestCommit = referenceCommits.getLatestCommit();
         String ancestor = validator.createClient().withRepository(new MergeBaseSelector(latestCommit));
         if (StringUtils.isNotEmpty(ancestor)) {
             logger.logInfo("-> found best common ancestor '%s' between HEAD and target branch commit '%s'",

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/GitRepositoryMiner.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/GitRepositoryMiner.java
@@ -49,7 +49,7 @@ public class GitRepositoryMiner extends RepositoryMiner {
             logger.merge(wrapped);
 
             List<CommitDiffItem> commits = wrapped.getResult();
-            logger.logInfo("-> created report in %d seconds", 1 + (System.nanoTime() - nano) / 1_000_000_000L);
+            logger.logInfo("-> Created report in %d seconds", 1 + (System.nanoTime() - nano) / 1_000_000_000L);
             CommitStatistics.logCommits(commits, logger);
 
             String latestCommitId;

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/MergeBaseSelector.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/MergeBaseSelector.java
@@ -38,8 +38,8 @@ class MergeBaseSelector implements RepositoryCallback<String> {
 
         RevWalk walk = new RevWalk(repository);
         walk.setRevFilter(RevFilter.MERGE_BASE);
-        walk.markStart(repository.parseCommit(target));
         walk.markStart(repository.parseCommit(head));
+        walk.markStart(repository.parseCommit(target));
 
         RevCommit next = walk.next();
         if (next == null) {

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/package-info.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/package-info.java
@@ -1,0 +1,24 @@
+/**
+ * Provides API classes to obtain commit statistics for files in a repository.
+ * <p>
+ * For pull requests (or more generally: for jobs that have a reference build defined) the classes in this package
+ * collect a statistical summary for all containing commits. This includes the commits count, the changed files count,
+ * and the added and deleted lines in those commits.
+ * </p>
+ * <p>
+ * Additionally, the classes in this package will collect commit statistics for all repository files in the style of
+ * the book "Code as a Crime Scene":
+ * <ul>
+ *     <li> commits count </li>
+ *     <li> different authors count </li>
+ *     <li> creation time </li>
+ *     <li> last modification time </li>
+ *     <li> lines of code (from the commit details) </li>
+ *     <li> code churn (changed lines since created) </li>
+ * </ul>
+ */
+@DefaultAnnotation(NonNull.class)
+package io.jenkins.plugins.forensics.git.miner;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/BuildCommits.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/BuildCommits.java
@@ -1,0 +1,78 @@
+package io.jenkins.plugins.forensics.git.reference;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.revwalk.RevCommit;
+
+import io.jenkins.plugins.forensics.git.reference.GitCommitsRecord.RecordingType;
+
+/**
+ * The commits of a given build. If these commits are part of a pull request then a target commit ID might be stored
+ * that defines the parent commit of the head in the target branch.
+ *
+ * @author Ullrich Hafner
+ */
+class BuildCommits implements Serializable {
+    private static final long serialVersionUID = -580006422072874429L;
+
+    private final String previousBuildCommit;
+
+    private final List<String> commits = new ArrayList<>();
+
+    private ObjectId head = ObjectId.zeroId();
+    private ObjectId target = ObjectId.zeroId();
+
+    BuildCommits(final String previousBuildCommit) {
+        this.previousBuildCommit = previousBuildCommit;
+    }
+
+    void setHead(final RevCommit head) {
+        this.head = head;
+    }
+
+    ObjectId getHead() {
+        return head;
+    }
+
+    void setTarget(final RevCommit target) {
+        this.target = target;
+    }
+
+    ObjectId getTarget() {
+        return target;
+    }
+
+    List<String> getCommits() {
+        return commits;
+    }
+
+    int size() {
+        return commits.size();
+    }
+
+    void add(final String commitId) {
+        commits.add(commitId);
+    }
+
+    boolean isEmpty() {
+        return commits.isEmpty();
+    }
+
+    RecordingType getRecordingType() {
+        if (StringUtils.isBlank(previousBuildCommit)) {
+            return RecordingType.START;
+        }
+        return RecordingType.INCREMENTAL;
+    }
+
+    String getLatestCommit() {
+        if (commits.isEmpty()) {
+            return previousBuildCommit;
+        }
+        return commits.get(0);
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCheckoutListener.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCheckoutListener.java
@@ -104,7 +104,8 @@ public class GitCheckoutListener extends SCMListener {
         if (record.isPresent()) {
             GitCommitsRecord previous = record.get();
             logger.logInfo("Found previous build '%s' that contains recorded Git commits", previous.getOwner());
-            logger.logInfo("-> Starting recording of new commits since '%s'", previous.getLatestCommit());
+            logger.logInfo("-> Starting recording of new commits since '%s'",
+                    DECORATOR.asText(previous.getLatestCommit()));
 
             return previous.getLatestCommit();
         }
@@ -221,21 +222,26 @@ public class GitCheckoutListener extends SCMListener {
             if (isMergeCommit) {
                 RevCommit[] parents = head.getParents();
                 if (parents.length < 1) {
-                    logger.logInfo("-> no parent commits found");
-                    logger.logInfo("-> using HEAD commit '%s' as starting point", DECORATOR.asText(head));
+                    logger.logInfo("-> No parent commits found - detected the first commit in the branch");
+                    logger.logInfo("-> Using head commit '%s' as starting point", DECORATOR.asText(head));
                     commits.setHead(head);
                 }
-                logger.logInfo("-> skipping commits of local merge '%s'", DECORATOR.asText(head));
-                commits.setMerge(head);
-                commits.setHead(parents[0]);
-                logger.logInfo("-> using parent commit '%s' of local merge as starting point", DECORATOR.asText(parents[0]));
-                if (parents.length > 1) {
-                    logger.logInfo("-> storing target branch head '%s' (second parent of local merge) ", DECORATOR.asText(parents[1]));
+                else if (parents.length == 1) {
+                    logger.logInfo("-> Single parent commit found - branch is already descendant of target branch head");
+                    logger.logInfo("-> Using head commit '%s' as starting point", DECORATOR.asText(head));
+                    commits.setHead(head);
+                }
+                else {
+                    logger.logInfo("-> Multiple parent commits found - skipping commits of local merge '%s'", DECORATOR.asText(head));
+                    commits.setMerge(head);
+                    commits.setHead(parents[0]);
+                    logger.logInfo("-> Using parent commit '%s' of local merge as starting point", DECORATOR.asText(parents[0]));
+                    logger.logInfo("-> Storing target branch head '%s' (second parent of local merge) ", DECORATOR.asText(parents[1]));
                     commits.setTarget(parents[1]);
                 }
             }
             else {
-                logger.logInfo("-> using HEAD commit '%s' as starting point", DECORATOR.asText(head));
+                logger.logInfo("-> Using head commit '%s' as starting point", DECORATOR.asText(head));
                 commits.setHead(head);
             }
         }

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCommitsCollector.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCommitsCollector.java
@@ -1,0 +1,104 @@
+package io.jenkins.plugins.forensics.git.reference;
+
+import java.io.IOException;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+
+import edu.hm.hafner.util.FilteredLog;
+
+import hudson.remoting.VirtualChannel;
+
+import io.jenkins.plugins.forensics.git.util.AbstractRepositoryCallback;
+import io.jenkins.plugins.forensics.git.util.GitCommitTextDecorator;
+import io.jenkins.plugins.forensics.git.util.RemoteResultWrapper;
+
+/**
+ * Collects and records all commits since the last build.
+ */
+class GitCommitsCollector extends AbstractRepositoryCallback<RemoteResultWrapper<BuildCommits>> {
+    private static final long serialVersionUID = -5980402198857923793L;
+
+    private static final GitCommitTextDecorator DECORATOR = new GitCommitTextDecorator();
+
+    private static final int MAX_COMMITS = 200; // TODO: should the number of recorded commits be configurable?
+
+    private final String latestRecordedCommit;
+    private final boolean isMergeCommit;
+
+    GitCommitsCollector(final String latestRecordedCommit, final boolean isMergeCommit) {
+        super();
+
+        this.latestRecordedCommit = latestRecordedCommit;
+        this.isMergeCommit = isMergeCommit;
+    }
+
+    @Override
+    public RemoteResultWrapper<BuildCommits> invoke(final Repository repository, final VirtualChannel channel)
+            throws IOException {
+        try (Git git = new Git(repository)) {
+            BuildCommits commits = new BuildCommits(latestRecordedCommit);
+            RemoteResultWrapper<BuildCommits> result = new RemoteResultWrapper<>(commits,
+                    "Errors while collecting commits");
+            findHeadCommit(repository, commits, result);
+            for (RevCommit commit : git.log().add(commits.getHead()).call()) {
+                String commitId = commit.getName();
+                if (commitId.equals(latestRecordedCommit) || commits.size() >= MAX_COMMITS) {
+                    return result;
+                }
+                commits.add(commitId);
+            }
+            return result;
+        }
+        catch (GitAPIException e) {
+            throw new IOException("Unable to record commits of git repository.", e);
+        }
+    }
+
+    private void findHeadCommit(final Repository repository, final BuildCommits commits, final FilteredLog logger)
+            throws IOException {
+        RevCommit head = getHead(repository);
+        if (isMergeCommit) {
+            RevCommit[] parents = head.getParents();
+            if (parents.length < 1) {
+                logger.logInfo("-> No parent commits found - detected the first commit in the branch");
+                logger.logInfo("-> Using head commit '%s' as starting point",
+                        DECORATOR.asText(head));
+                commits.setHead(head);
+            }
+            else if (parents.length == 1) {
+                logger.logInfo("-> Single parent commit found - branch is already descendant of target branch head");
+                logger.logInfo("-> Using head commit '%s' as starting point",
+                        DECORATOR.asText(head));
+                commits.setHead(head);
+            }
+            else {
+                logger.logInfo("-> Multiple parent commits found - skipping commits of local merge '%s'",
+                        DECORATOR.asText(head));
+                logger.logInfo("-> Using parent commit '%s' of local merge as starting point",
+                        DECORATOR.asText(parents[0]));
+                logger.logInfo("-> Storing target branch head '%s' (second parent of local merge) ",
+                        DECORATOR.asText(parents[1]));
+                commits.setHead(parents[0]);
+                commits.setTarget(parents[1]);
+            }
+        }
+        else {
+            logger.logInfo("-> Using head commit '%s' as starting point", DECORATOR.asText(head));
+            commits.setHead(head);
+        }
+    }
+
+    private RevCommit getHead(final Repository repository) throws IOException {
+        ObjectId head = repository.resolve(Constants.HEAD);
+        if (head == null) {
+            throw new IOException("No HEAD commit found in " + repository);
+        }
+        return new RevWalk(repository).parseCommit(head);
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCommitsRecord.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCommitsRecord.java
@@ -15,7 +15,7 @@ import hudson.model.Run;
 import hudson.scm.SCM;
 import jenkins.model.RunAction2;
 
-import io.jenkins.plugins.forensics.git.reference.GitCheckoutListener.Commits;
+import io.jenkins.plugins.forensics.git.reference.GitCheckoutListener.BuildCommits;
 
 /**
  * Stores all commits for a given build and provides a link to the latest commit. For each {@link SCM} repository a
@@ -64,7 +64,7 @@ public class GitCommitsRecord implements RunAction2, Serializable {
      *         hyperlink to the latest commit
      */
     public GitCommitsRecord(final Run<?, ?> owner, final String scmKey, final FilteredLog logger,
-            final Commits commits, final String latestCommitLink) {
+            final BuildCommits commits, final String latestCommitLink) {
         this.owner = owner;
         this.scmKey = scmKey;
         this.infoMessages = new ArrayList<>(logger.getInfoMessages());

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCommitsRecord.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCommitsRecord.java
@@ -6,6 +6,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.eclipse.jgit.lib.ObjectId;
+
 import edu.hm.hafner.util.FilteredLog;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -36,6 +38,7 @@ public class GitCommitsRecord implements RunAction2, Serializable {
     private final String latestCommit;
     private final RecordingType recordingType;
     private final String latestCommitLink;
+    private final String targetParentCommit;
     private final List<String> commits;
     private final List<String> errorMessages;
     private final List<String> infoMessages;
@@ -70,6 +73,7 @@ public class GitCommitsRecord implements RunAction2, Serializable {
         this.latestCommitLink = latestCommitLink;
         this.commits = new ArrayList<>(commits.getCommits());
         this.recordingType = commits.getRecordingType();
+        targetParentCommit = commits.getTarget().name();
     }
 
     public Run<?, ?> getOwner() {
@@ -90,6 +94,19 @@ public class GitCommitsRecord implements RunAction2, Serializable {
 
     public String getLatestCommitLink() {
         return latestCommitLink;
+    }
+
+    public String getTargetParentCommit() {
+        return targetParentCommit;
+    }
+
+    /**
+     * Determines if the commits contain a merge commit with the target branch.
+     *
+     * @return {@code true} if the commits contain a merge commit with the target branch
+     */
+    public boolean hasTargetParentCommit() {
+        return !ObjectId.zeroId().name().equals(targetParentCommit);
     }
 
     public List<String> getErrorMessages() {
@@ -123,6 +140,18 @@ public class GitCommitsRecord implements RunAction2, Serializable {
 
     public List<String> getCommits() {
         return commits;
+    }
+
+    /**
+     * Returns {@code true} if the specified commit is part of the commits.
+     *
+     * @param commit
+     *         the commit to search for
+     *
+     * @return {@code true} if the commits contain the specified commit, {@code false} otherwise
+     */
+    public boolean contains(final String commit) {
+        return commits.contains(commit);
     }
 
     @Override

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCommitsRecord.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCommitsRecord.java
@@ -15,8 +15,6 @@ import hudson.model.Run;
 import hudson.scm.SCM;
 import jenkins.model.RunAction2;
 
-import io.jenkins.plugins.forensics.git.reference.GitCheckoutListener.BuildCommits;
-
 /**
  * Stores all commits for a given build and provides a link to the latest commit. For each {@link SCM} repository a
  * unique {@link GitCommitsRecord} instance will be used.
@@ -33,7 +31,7 @@ public class GitCommitsRecord implements RunAction2, Serializable {
      * Key of the repository. The {@link GitCheckoutListener} ensures that a single action will be created for each
      * repository.
      */
-    // FIXME: move up to a CommitsBusinessObject
+    // TODO: maybe it makes sense to move these values to a business object that is not loaded every time
     private final String scmKey;
     private final String latestCommit;
     private final RecordingType recordingType;

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/util/GitCommitTextDecorator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/util/GitCommitTextDecorator.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.forensics.git.util;
 
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jgit.lib.ObjectId;
 
 import io.jenkins.plugins.forensics.util.CommitDecorator;
 
@@ -15,8 +16,32 @@ public class GitCommitTextDecorator extends CommitDecorator {
         return asText(id);
     }
 
+    /**
+     * Obtains a link for the specified commit ID.
+     *
+     * @param id
+     *         the ID of the commit
+     *
+     * @return an HTML a tag that contains a link to the commit
+     */
+    public String asLink(final ObjectId id) {
+        return asLink(id.name());
+    }
+
     @Override
     public String asText(final String id) {
         return StringUtils.substring(id, 0, 7);
+    }
+
+    /**
+     * Renders the commit ID as a human-readable text.
+     *
+     * @param id
+     *         the ID of the commit
+     *
+     * @return a commit ID as human-readable text
+     */
+    public String asText(final ObjectId id) {
+        return asText(id.name());
     }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/util/package-info.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/util/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Provides utility classes to access Git repositories and to render Git commit hashes.
+ */
+@DefaultAnnotation(NonNull.class)
+package io.jenkins.plugins.forensics.git.util;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/miner/GitMinerStepITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/miner/GitMinerStepITest.java
@@ -82,7 +82,6 @@ public class GitMinerStepITest extends GitITest {
     /** Verifies that the mining process is incremental and scans only new commits. */
     @Test
     public void shouldMineRepositoryIncrementally() {
-        String firstCommit = getHead();
         writeFileAsAuthorFoo("1\n2\n3\n");
         String secondCommit = getHead();
 
@@ -95,10 +94,7 @@ public class GitMinerStepITest extends GitITest {
 
         assertThat(getConsoleLog(firstBuild)).contains(
                 "2 commits analyzed",
-                "2 MODIFY commit diff items",
-                String.format("Analyzed commit '%s'", firstCommit),
-                String.format("Analyzed commit '%s'", secondCommit)
-        );
+                "2 MODIFY commit diff items");
         verifyStatistics(statistics, ADDITIONAL_FILE, 1, 1);
 
         Run<?, ?> secondBuild = buildSuccessfully(job);
@@ -109,23 +105,18 @@ public class GitMinerStepITest extends GitITest {
         verifyStatistics(getStatistics(secondBuild), ADDITIONAL_FILE, 1, 1);
 
         writeFileAsAuthorFoo("Third");
-        String thirdCommit = getHead();
 
         Run<?, ?> thirdBuild = buildSuccessfully(job);
 
         assertThat(getConsoleLog(thirdBuild)).contains(
                 "1 commits analyzed",
-                "1 MODIFY commit diff items",
-                String.format("Analyzed commit '%s'", thirdCommit));
+                "1 MODIFY commit diff items");
         verifyStatistics(getStatistics(thirdBuild), ADDITIONAL_FILE, 1, 2);
 
         writeFileAsAuthorBar("Another content");
         Run<?, ?> build = buildSuccessfully(job);
 
-        assertThat(getConsoleLog(thirdBuild)).contains(
-                "1 commits analyzed",
-                "1 MODIFY commit diff items",
-                String.format("Analyzed commit '%s'", thirdCommit));
+        assertThat(getConsoleLog(thirdBuild)).contains("1 commits analyzed", "1 MODIFY commit diff items");
         verifyStatistics(getStatistics(build), ADDITIONAL_FILE, 2, 3);
     }
 
@@ -144,11 +135,7 @@ public class GitMinerStepITest extends GitITest {
         assertThat(statistics).hasFiles(INITIAL_FILE, moved);
         assertThat(statistics).hasLatestCommitId(getHead());
 
-        assertThat(getConsoleLog(build)).contains(
-                "1 commits analyzed",
-                "1 RENAME commit diff items",
-                String.format("Analyzed commit '%s'", getHead())
-        );
+        assertThat(getConsoleLog(build)).contains("1 commits analyzed", "1 RENAME commit diff items");
         verifyStatistics(statistics, moved, 2, 5);
 
         TableModel forensics = getTableModel(build);
@@ -182,11 +169,7 @@ public class GitMinerStepITest extends GitITest {
         assertThat(statistics).hasFiles(INITIAL_FILE);
         assertThat(statistics).hasLatestCommitId(getHead());
 
-        assertThat(getConsoleLog(build)).contains(
-                "1 commits analyzed",
-                "1 DELETE commit diff items",
-                String.format("Analyzed commit '%s'", getHead())
-        );
+        assertThat(getConsoleLog(build)).contains("1 commits analyzed", "1 DELETE commit diff items");
 
         TableModel forensics = getTableModel(build);
         assertThat(forensics.getRows()).hasSize(1);

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitCheckoutListenerITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitCheckoutListenerITest.java
@@ -12,6 +12,7 @@ import hudson.model.FreeStyleProject;
 import hudson.plugins.git.GitSCM;
 import jenkins.plugins.git.GitSampleRepoRule;
 
+import io.jenkins.plugins.forensics.git.util.GitCommitTextDecorator;
 import io.jenkins.plugins.util.IntegrationTestWithJenkinsPerSuite;
 
 import static io.jenkins.plugins.forensics.git.assertions.Assertions.*;
@@ -24,6 +25,8 @@ import static io.jenkins.plugins.forensics.git.assertions.Assertions.*;
  */
 @SuppressWarnings("PMD.SignatureDeclareThrowsException")
 public class GitCheckoutListenerITest extends IntegrationTestWithJenkinsPerSuite {
+    private static final GitCommitTextDecorator RENDERER = new GitCommitTextDecorator();
+
     private static final String GIT_FORENSICS_URL = "https://github.com/jenkinsci/git-forensics-plugin.git";
     private static final String FORENSICS_API_URL = "https://github.com/jenkinsci/forensics-api-plugin.git";
 
@@ -73,7 +76,10 @@ public class GitCheckoutListenerITest extends IntegrationTestWithJenkinsPerSuite
                 .hasNoErrorMessages().hasInfoMessages("-> Recorded one new commit",
                 String.format("Found previous build '%s' that contains recorded Git commits",
                         referenceBuild.getOwner()),
-                String.format("-> Starting recording of new commits since '%s'", referenceBuildHead));
+                String.format("-> Starting recording of new commits since '%s'",
+                        RENDERER.asText(referenceBuildHead)),
+                String.format("-> Using head commit '%s' as starting point",
+                        RENDERER.asText(nextBuildHead)));
     }
 
     /**

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderITest.java
@@ -488,9 +488,9 @@ public class GitReferenceRecorderITest extends GitITest {
                 .hasReferenceBuild(Optional.of(nextMaster));
 
         assertThat(getCommitStatisticsOf(featureBuild))
-                .hasCommitCount(4)
+                .hasCommitCount(2)
                 .hasFilesCount(3)
-                .hasAddedLines(6)
+                .hasAddedLines(3)
                 .hasDeletedLines(3);
     }
 

--- a/ui-tests/pom.xml
+++ b/ui-tests/pom.xml
@@ -155,7 +155,7 @@
           <environmentVariables>
             <PLUGINS_DIR>../plugin/target/test-classes/test-dependencies</PLUGINS_DIR>
             <JENKINS_VERSION>${jenkins.version}</JENKINS_VERSION>
-            <BROWSER>chrome-container</BROWSER>
+            <BROWSER>firefox-container</BROWSER>
           </environmentVariables>
           <rerunFailingTestsCount>1</rerunFailingTestsCount>
           <includes>


### PR DESCRIPTION
PR builds are already merged with master, so the merge commit needs to be removed.
Restructure the commit listener to record not only new commits but also the branching point.

