### PR TITLE
[JENKINS-66403] When obtaining the Git commits of a build always check the SCM key

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCheckoutListener.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCheckoutListener.java
@@ -62,12 +62,7 @@ public class GitCheckoutListener extends SCMListener {
     }
 
     private boolean hasRecordForScm(final Run<?, ?> build, final String scmKey) {
-        return findRecordForScm(build, scmKey).isPresent();
-    }
-
-    private Optional<GitCommitsRecord> findRecordForScm(final Run<?, ?> build, final String scmKey) {
-        return build.getActions(GitCommitsRecord.class)
-                .stream().filter(record -> scmKey.equals(record.getScmKey())).findAny();
+        return GitCommitsRecord.findRecordForScm(build, scmKey).isPresent();
     }
 
     private void recordNewCommits(final Run<?, ?> build, final GitRepositoryValidator gitRepository,
@@ -157,7 +152,7 @@ public class GitCheckoutListener extends SCMListener {
 
     private Optional<GitCommitsRecord> getPreviousRecord(final Run<?, ?> currentBuild, final String scmKey) {
         for (Run<?, ?> build = currentBuild.getPreviousBuild(); build != null; build = build.getPreviousBuild()) {
-            Optional<GitCommitsRecord> record = findRecordForScm(build, scmKey);
+            Optional<GitCommitsRecord> record = GitCommitsRecord.findRecordForScm(build, scmKey);
             if (record.isPresent()) {
                 return record;
             }

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCommitsRecord.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCommitsRecord.java
@@ -33,10 +33,11 @@ public class GitCommitsRecord implements RunAction2, Serializable {
      * @param scmKey
      *         the ID of the SCM repository
      *
+     * @return the commits record, if found
      */
     public static Optional<GitCommitsRecord> findRecordForScm(final Run<?, ?> build, final String scmKey) {
         return build.getActions(GitCommitsRecord.class)
-                .stream().filter(record -> scmKey.equals(record.getScmKey())).findAny();
+                .stream().filter(record -> record.getScmKey().contains(scmKey)).findAny();
     }
 
     private transient Run<?, ?> owner;

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCommitsRecord.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCommitsRecord.java
@@ -25,6 +25,20 @@ import jenkins.model.RunAction2;
 public class GitCommitsRecord implements RunAction2, Serializable {
     private static final long serialVersionUID = 8994811233847179343L;
 
+    /**
+     * Tries to find a {@link GitCommitsRecord} for the specified SCM.
+     *
+     * @param build
+     *         the build to search for corresponding {@link GitCommitsRecord} actions
+     * @param scmKey
+     *         the ID of the SCM repository
+     *
+     */
+    public static Optional<GitCommitsRecord> findRecordForScm(final Run<?, ?> build, final String scmKey) {
+        return build.getActions(GitCommitsRecord.class)
+                .stream().filter(record -> scmKey.equals(record.getScmKey())).findAny();
+    }
+
     private transient Run<?, ?> owner;
 
     /**
@@ -227,10 +241,7 @@ public class GitCommitsRecord implements RunAction2, Serializable {
     }
 
     private List<String> getCommitsForRepository(final Run<?, ?> run) {
-        return run.getActions(GitCommitsRecord.class)
-                .stream()
-                .filter(gc -> this.getScmKey().equals(gc.getScmKey()))
-                .findAny()
+        return findRecordForScm(run, getScmKey())
                 .map(GitCommitsRecord::getCommits)
                 .orElse(Collections.emptyList());
     }

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder.java
@@ -82,23 +82,16 @@ public class GitReferenceRecorder extends ReferenceRecorder {
 
     @Override
     protected Optional<Run<?, ?>> find(final Run<?, ?> owner, final Run<?, ?> lastCompletedBuildOfReferenceJob) {
-        Optional<GitCommitsRecord> referenceCommit = getCommitsFor(lastCompletedBuildOfReferenceJob);
+        Optional<GitCommitsRecord> referenceCommit = GitCommitsRecord.findRecordForScm(lastCompletedBuildOfReferenceJob, getScm());
         if (!referenceCommit.isPresent()) {
             return Optional.empty();
         }
 
-        Optional<GitCommitsRecord> thisCommit = getCommitsFor(owner);
+        Optional<GitCommitsRecord> thisCommit = GitCommitsRecord.findRecordForScm(owner, getScm());
         if (thisCommit.isPresent()) {
             return thisCommit.get().getReferencePoint(referenceCommit.get(), getMaxCommits(), isSkipUnknownCommits());
         }
         return Optional.empty();
-    }
-
-    private Optional<GitCommitsRecord> getCommitsFor(final Run<?, ?> lastCompletedBuildOfReferenceJob) {
-        return lastCompletedBuildOfReferenceJob.getActions(GitCommitsRecord.class)
-                .stream()
-                .filter(r -> r.getScmKey().contains(getScm()))
-                .findFirst();
     }
 
     @Override


### PR DESCRIPTION
Some code paths obtained the `GitCommitAction` from a build without checking the correct SCM ID. This may lead to errors when scanning for commits in the wrong SCM. 

See [JENKINS-66403](https://issues.jenkins.io/browse/JENKINS-66403).