### PR TITLE
[JENKINS-66480] Add fallback reference build for multibranch projects.

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -28,7 +28,7 @@
     <echarts-api.version>5.2.1-2</echarts-api.version>
     <plugin-util-api.version>2.5.0</plugin-util-api.version>
     <data-tables-api.version>1.11.3-1</data-tables-api.version>
-    <forensics-api-plugin.version>1.6.0-rc1097.66cbb7e5be8d</forensics-api-plugin.version>
+    <forensics-api-plugin.version>1.6.0-rc1103.85ae25a1ba43</forensics-api-plugin.version>
     <j2html.version>1.4.0</j2html.version>
     <streamex.version>0.7.3</streamex.version>
   </properties>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -28,7 +28,7 @@
     <echarts-api.version>5.2.1-2</echarts-api.version>
     <plugin-util-api.version>2.5.0</plugin-util-api.version>
     <data-tables-api.version>1.11.3-1</data-tables-api.version>
-    <forensics-api-plugin.version>1.5.0</forensics-api-plugin.version>
+    <forensics-api-plugin.version>1.6.0-rc1097.66cbb7e5be8d</forensics-api-plugin.version>
     <j2html.version>1.4.0</j2html.version>
     <streamex.version>0.7.3</streamex.version>
   </properties>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -28,7 +28,7 @@
     <echarts-api.version>5.2.1-2</echarts-api.version>
     <plugin-util-api.version>2.5.0</plugin-util-api.version>
     <data-tables-api.version>1.11.3-1</data-tables-api.version>
-    <forensics-api-plugin.version>1.6.0-rc1103.85ae25a1ba43</forensics-api-plugin.version>
+    <forensics-api-plugin.version>1.6.0-rc1111.c4a7a6afe019</forensics-api-plugin.version>
     <j2html.version>1.4.0</j2html.version>
     <streamex.version>0.7.3</streamex.version>
   </properties>

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCommitsRecord.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCommitsRecord.java
@@ -250,12 +250,6 @@ public class GitCommitsRecord implements RunAction2, Serializable {
                     getHeadCommitOf(additionalCommits, textDecorator));
 
             if (!skipUnknownCommits || branchCommits.containsAll(additionalCommits)) {
-                if (skipUnknownCommits) {
-                    logger.logInfo("-> all commits of target branch are part of the current build");
-                }
-                else {
-                    logger.logInfo("-> ignoring if some of the commits are not part of the current branch build");
-                }
                 targetCommits.addAll(additionalCommits);
                 Optional<String> referencePoint = branchCommits.stream().filter(targetCommits::contains).findFirst();
                 if (referencePoint.isPresent()) {

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder.java
@@ -16,13 +16,10 @@ import org.jenkinsci.Symbol;
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.model.Item;
-import hudson.model.Job;
 import hudson.model.Run;
 import hudson.util.ComboBoxModel;
 import hudson.util.FormValidation;
 import jenkins.scm.api.SCMHead;
-import jenkins.scm.api.SCMHead.HeadByItem;
-import jenkins.scm.api.mixin.ChangeRequestSCMHead;
 
 import io.jenkins.plugins.forensics.reference.ReferenceRecorder;
 import io.jenkins.plugins.util.JenkinsFacade;
@@ -128,16 +125,6 @@ public class GitReferenceRecorder extends ReferenceRecorder {
     @SuppressFBWarnings("BC")
     public Descriptor getDescriptor() {
         return (Descriptor) super.getDescriptor();
-    }
-
-    static class ScmFacade {
-        Optional<ChangeRequestSCMHead> findHead(final Job<?, ?> job) {
-            SCMHead head = HeadByItem.findHead(job);
-            if (head instanceof ChangeRequestSCMHead) {
-                return Optional.of((ChangeRequestSCMHead) head);
-            }
-            return Optional.empty();
-        }
     }
 
     /**

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder.java
@@ -134,12 +134,15 @@ public class GitReferenceRecorder extends ReferenceRecorder {
         /**
          * Creates a new descriptor with the concrete services.
          */
+        @SuppressWarnings("unused") // Required for extension point
         public Descriptor() {
             this(new JenkinsFacade(), new GitReferenceJobModelValidation());
         }
 
         @VisibleForTesting
         Descriptor(final JenkinsFacade  jenkins, final GitReferenceJobModelValidation model) {
+            super();
+
             this.jenkins = jenkins;
             this.model = model;
         }

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder.java
@@ -52,8 +52,9 @@ public class GitReferenceRecorder extends ReferenceRecorder {
     }
 
     /**
-     * Sets the maximal number of commits that will be compared with the builds of the reference job to find the
-     * matching reference build.
+     * Sets the maximal number of additional commits in the reference job that will be considered during the
+     * comparison with the current branch. In order to avoid an indefinite scanning of the build history until a
+     * matching reference has been found this value is used as a stop criteria.
      *
      * @param maxCommits
      *         maximal number of commits

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderITest.java
@@ -720,6 +720,7 @@ public class GitReferenceRecorderITest extends GitITest {
         return verifyBuild(project, buildNumber, FEATURE, FEATURE.toUpperCase(Locale.ENGLISH) + " CONTENT");
     }
 
+    @SuppressWarnings("PMD.SystemPrintln")
     private WorkflowRun verifyBuild(final WorkflowMultiBranchProject project, final int buildNumber,
             final String branch, final String branchContent) {
         try {

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderTest.java
@@ -1,0 +1,71 @@
+package io.jenkins.plugins.forensics.git.reference;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.Item;
+import hudson.util.ComboBoxModel;
+import hudson.util.FormValidation;
+
+import io.jenkins.plugins.forensics.git.reference.GitReferenceRecorder.Descriptor;
+import io.jenkins.plugins.util.JenkinsFacade;
+
+import static io.jenkins.plugins.forensics.git.assertions.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the class {@link GitReferenceRecorder}.
+ *
+ * @author Ullrich Hafner
+ */
+class GitReferenceRecorderTest {
+    private static final String JOB_NAME = "reference";
+    private static final FormValidation ERROR = FormValidation.error("error");
+    private static final FormValidation OK = FormValidation.ok();
+
+    @Nested
+    class DescriptorTest {
+        @Test
+        void shouldValidateJobName() {
+            GitReferenceJobModelValidation model = mock(GitReferenceJobModelValidation.class);
+            when(model.validateJob(JOB_NAME)).thenReturn(ERROR, OK);
+
+            JenkinsFacade jenkins = mock(JenkinsFacade.class);
+
+            Descriptor descriptor = new Descriptor(jenkins, model);
+
+            FreeStyleProject project = mock(FreeStyleProject.class);
+            assertThat(descriptor.doCheckReferenceJob(project, JOB_NAME)).isEqualTo(OK);
+            verifyNoInteractions(model);
+
+            // Now enable permission
+            when(jenkins.hasPermission(Item.CONFIGURE, project)).thenReturn(true);
+            // first call stub returns ERROR
+            assertThat(descriptor.doCheckReferenceJob(project, JOB_NAME)).isEqualTo(ERROR);
+            // second call stub returns ERROR
+            assertThat(descriptor.doCheckReferenceJob(project, JOB_NAME)).isEqualTo(OK);
+        }
+
+        @Test
+        void shouldFillModel() {
+            GitReferenceJobModelValidation model = mock(GitReferenceJobModelValidation.class);
+            ComboBoxModel jobs = new ComboBoxModel();
+            jobs.add("A Job");
+            when(model.getAllJobs()).thenReturn(jobs);
+
+            JenkinsFacade jenkins = mock(JenkinsFacade.class);
+
+            Descriptor descriptor = new Descriptor(jenkins, model);
+
+
+            FreeStyleProject project = mock(FreeStyleProject.class);
+            assertThat(descriptor.doFillReferenceJobItems(project)).isEqualTo(new ComboBoxModel());
+            verifyNoInteractions(model);
+
+            // Now enable permission
+            when(jenkins.hasPermission(Item.CONFIGURE, project)).thenReturn(true);
+            assertThat(descriptor.doFillReferenceJobItems(project)).isEqualTo(jobs);
+        }
+    }
+}


### PR DESCRIPTION
If the reference build detection does not work because the number of recorded commits is not large enough, then as a
fallback for pull requests the last build of the target branch will be returned as reference build.
