### PR TITLE
Git implementation for delta API

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -29,7 +29,7 @@
     <font-awesome-api.version>5.15.4-5</font-awesome-api.version>
     <plugin-util-api.version>2.13.0</plugin-util-api.version>
     <data-tables-api.version>1.11.3-1</data-tables-api.version>
-    <forensics-api-plugin.version>1.8.0-rc1182.3b11c07bfc31</forensics-api-plugin.version>
+    <forensics-api-plugin.version>1.8.0-rc1193.c415577564b8</forensics-api-plugin.version>
     <bootstrap5-api.version>5.1.3-4</bootstrap5-api.version>
     <streamex.version>0.8.1</streamex.version>
   </properties>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -29,7 +29,7 @@
     <font-awesome-api.version>5.15.4-3</font-awesome-api.version>
     <plugin-util-api.version>2.5.1</plugin-util-api.version>
     <data-tables-api.version>1.11.3-1</data-tables-api.version>
-    <forensics-api-plugin.version>1.8.0-rc1147.37a46657bd0d</forensics-api-plugin.version>
+    <forensics-api-plugin.version>1.8.0-rc1149.c59a6e6ded1c</forensics-api-plugin.version>
     <j2html.version>1.4.0</j2html.version>
     <streamex.version>0.8.0</streamex.version>
   </properties>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -18,7 +18,7 @@
   <url>https://github.com/jenkinsci/git-forensics-plugin</url>
 
   <properties>
-    <revision>1.4.0</revision>
+    <revision>1.5.0</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <module.name>${project.groupId}.git.forensics</module.name>
@@ -29,7 +29,7 @@
     <font-awesome-api.version>5.15.4-3</font-awesome-api.version>
     <plugin-util-api.version>2.5.1</plugin-util-api.version>
     <data-tables-api.version>1.11.3-1</data-tables-api.version>
-    <forensics-api-plugin.version>1.7.0</forensics-api-plugin.version>
+    <forensics-api-plugin.version>1.9.0</forensics-api-plugin.version>
     <j2html.version>1.4.0</j2html.version>
     <streamex.version>0.8.0</streamex.version>
   </properties>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -18,7 +18,7 @@
   <url>https://github.com/jenkinsci/git-forensics-plugin</url>
 
   <properties>
-    <revision>1.5.0</revision>
+    <revision>1.4.0</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <module.name>${project.groupId}.git.forensics</module.name>
@@ -29,7 +29,7 @@
     <font-awesome-api.version>5.15.4-3</font-awesome-api.version>
     <plugin-util-api.version>2.5.1</plugin-util-api.version>
     <data-tables-api.version>1.11.3-1</data-tables-api.version>
-    <forensics-api-plugin.version>1.9.0</forensics-api-plugin.version>
+    <forensics-api-plugin.version>1.8.0-rc1147.37a46657bd0d</forensics-api-plugin.version>
     <j2html.version>1.4.0</j2html.version>
     <streamex.version>0.8.0</streamex.version>
   </properties>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -29,7 +29,7 @@
     <font-awesome-api.version>5.15.4-4</font-awesome-api.version>
     <plugin-util-api.version>2.7.0</plugin-util-api.version>
     <data-tables-api.version>1.11.3-1</data-tables-api.version>
-    <forensics-api-plugin.version>1.8.0-rc1149.c59a6e6ded1c</forensics-api-plugin.version>
+    <forensics-api-plugin.version>1.8.0-rc1158.89b67ff83da5</forensics-api-plugin.version>
     <j2html.version>1.4.0</j2html.version>
     <streamex.version>0.8.0</streamex.version>
   </properties>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -29,7 +29,7 @@
     <font-awesome-api.version>5.15.4-5</font-awesome-api.version>
     <plugin-util-api.version>2.12.0</plugin-util-api.version>
     <data-tables-api.version>1.11.3-1</data-tables-api.version>
-    <forensics-api-plugin.version>1.7.0</forensics-api-plugin.version>
+    <forensics-api-plugin.version>1.8.0-rc1182.3b11c07bfc31</forensics-api-plugin.version>
     <bootstrap5-api.version>5.1.3-4</bootstrap5-api.version>
     <streamex.version>0.8.1</streamex.version>
   </properties>

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/DeltaRepositoryCallback.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/DeltaRepositoryCallback.java
@@ -18,6 +18,7 @@ import org.eclipse.jgit.revwalk.RevWalk;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -41,7 +42,14 @@ public class DeltaRepositoryCallback extends AbstractRepositoryCallback<RemoteRe
      */
     private final String referenceCommitId;
 
+    /**
+     * Creates an instance which can be used for executing a Git repository callback.
+     *
+     * @param currentCommitId The commit ID of the currently processed commit
+     * @param referenceCommitId The commit ID of the reference commit.
+     */
     public DeltaRepositoryCallback(final String currentCommitId, final String referenceCommitId) {
+        super();
         this.currentCommitId = currentCommitId;
         this.referenceCommitId = referenceCommitId;
     }
@@ -111,7 +119,7 @@ public class DeltaRepositoryCallback extends AbstractRepositoryCallback<RemoteRe
                 fileChangesMap.put(diffEntry.getNewId().name(), fileChanges);
             }
 
-            String diffFile = diffStream.toString();
+            String diffFile = new String(diffStream.toByteArray(), StandardCharsets.UTF_8);
             delta.setDiffFile(diffFile);
             delta.setFileChanges(fileChangesMap);
         }
@@ -130,7 +138,7 @@ public class DeltaRepositoryCallback extends AbstractRepositoryCallback<RemoteRe
     private String getFileContent(final ObjectId fileId, final Repository repository) throws IOException {
         ObjectDatabase objectDatabase = repository.getObjectDatabase();
         ObjectLoader objectLoader = objectDatabase.open(fileId);
-        return new String(objectLoader.getBytes());
+        return new String(objectLoader.getBytes(), StandardCharsets.UTF_8);
     }
 
     /**

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/DeltaRepositoryCallback.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/DeltaRepositoryCallback.java
@@ -56,12 +56,9 @@ public class DeltaRepositoryCallback extends AbstractRepositoryCallback<RemoteRe
      * Calculates the delta between the commits {@link #currentCommitId} and {@link #referenceCommitId} by using the Git
      * repository.
      *
-     * @param repository
-     *         The Git repository.
-     *
+     * @param repository The Git repository.
      * @return a serializable wrapper containing the delta
-     * @throws IOException
-     *         if communicating with Git failed
+     * @throws IOException if communicating with Git failed
      */
     private RemoteResultWrapper<Delta> calculateDelta(final Repository repository) throws IOException {
         Delta delta = new Delta(currentCommitId, referenceCommitId);
@@ -125,14 +122,10 @@ public class DeltaRepositoryCallback extends AbstractRepositoryCallback<RemoteRe
     /**
      * Reads the content of a file which is specified by its id - the {@link ObjectId}.
      *
-     * @param fileId
-     *         The file id
-     * @param repository
-     *         The Git repository
-     *
+     * @param fileId     The file id
+     * @param repository The Git repository
      * @return the file content
-     * @throws IOException
-     *         if reading failed
+     * @throws IOException if reading failed
      */
     private String getFileContent(final ObjectId fileId, final Repository repository) throws IOException {
         ObjectDatabase objectDatabase = repository.getObjectDatabase();
@@ -143,9 +136,7 @@ public class DeltaRepositoryCallback extends AbstractRepositoryCallback<RemoteRe
     /**
      * Transforms the Git specific {@link ChangeType} to the general model {@link FileEditType}.
      *
-     * @param type
-     *         The Git specific change type
-     *
+     * @param type The Git specific change type
      * @return the transformed general type
      */
     private FileEditType getFileEditType(final ChangeType type) {
@@ -168,9 +159,7 @@ public class DeltaRepositoryCallback extends AbstractRepositoryCallback<RemoteRe
     /**
      * Transforms the Git specific {@link Edit.Type} to the general model {@link ChangeEditType}.
      *
-     * @param type
-     *         The Git specific edit type
-     *
+     * @param type The Git specific edit type
      * @return the transformed general type
      */
     private ChangeEditType getChangeEditType(final Edit.Type type) {
@@ -191,10 +180,8 @@ public class DeltaRepositoryCallback extends AbstractRepositoryCallback<RemoteRe
     /**
      * Processes an edit on a file and adds it to a map which key are the {@link ChangeEditType}.
      *
-     * @param edit
-     *         The edit to be processed
-     * @param changesByType
-     *         The map to which edits are added to after processing
+     * @param edit          The edit to be processed
+     * @param changesByType The map to which edits are added to after processing
      */
     private void addChangeByType(final Edit edit, final Map<ChangeEditType, List<Change>> changesByType) {
         ChangeEditType changeEditType = getChangeEditType(edit.getType());

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/DeltaRepositoryCallback.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/DeltaRepositoryCallback.java
@@ -1,9 +1,12 @@
 package io.jenkins.plugins.forensics.git.delta;
 
-import hudson.remoting.VirtualChannel;
-import io.jenkins.plugins.forensics.delta.model.*;
-import io.jenkins.plugins.forensics.git.util.AbstractRepositoryCallback;
-import io.jenkins.plugins.forensics.git.util.RemoteResultWrapper;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.diff.DiffEntry.ChangeType;
 import org.eclipse.jgit.diff.DiffFormatter;
@@ -16,13 +19,18 @@ import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import edu.hm.hafner.util.FilteredLog;
+
+import hudson.remoting.VirtualChannel;
+
+import io.jenkins.plugins.forensics.delta.model.Change;
+import io.jenkins.plugins.forensics.delta.model.ChangeEditType;
+import io.jenkins.plugins.forensics.delta.model.Delta;
+import io.jenkins.plugins.forensics.delta.model.FileChanges;
+import io.jenkins.plugins.forensics.delta.model.FileEditType;
+import io.jenkins.plugins.forensics.git.delta.model.GitDelta;
+import io.jenkins.plugins.forensics.git.util.AbstractRepositoryCallback;
+import io.jenkins.plugins.forensics.git.util.RemoteResultWrapper;
 
 /**
  * Repository callback that calculates the code difference - so called 'delta' - between two commits.
@@ -31,22 +39,23 @@ import java.util.Map;
  */
 public class DeltaRepositoryCallback extends AbstractRepositoryCallback<RemoteResultWrapper<Delta>> {
 
+    static final String ERROR_MESSAGE_UNKNOWN_FILE_EDIT_TYPE = "Detected unknown file edit type '%s'";
+
+    static final String ERROR_MESSAGE_UNKNOWN_CHANGE_TYPE = "Detected unknown change type '%s'";
+
     private static final long serialVersionUID = -4561284338216569043L;
 
-    /**
-     * The currently processed commit.
-     */
     private final String currentCommitId;
-    /**
-     * The reference commit to calculate the delta to.
-     */
+
     private final String referenceCommitId;
 
     /**
      * Creates an instance which can be used for executing a Git repository callback.
      *
-     * @param currentCommitId The commit ID of the currently processed commit
-     * @param referenceCommitId The commit ID of the reference commit.
+     * @param currentCommitId
+     *         The commit ID of the currently processed commit
+     * @param referenceCommitId
+     *         The commit ID of the reference commit.
      */
     public DeltaRepositoryCallback(final String currentCommitId, final String referenceCommitId) {
         super();
@@ -64,87 +73,117 @@ public class DeltaRepositoryCallback extends AbstractRepositoryCallback<RemoteRe
      * Calculates the delta between the commits {@link #currentCommitId} and {@link #referenceCommitId} by using the Git
      * repository.
      *
-     * @param repository The Git repository.
+     * @param repository
+     *         The Git repository.
+     *
      * @return a serializable wrapper containing the delta
-     * @throws IOException if communicating with Git failed
+     * @throws IOException
+     *         if communicating with Git failed
      */
     private RemoteResultWrapper<Delta> calculateDelta(final Repository repository) throws IOException {
-        Delta delta = new Delta(currentCommitId, referenceCommitId);
-        RemoteResultWrapper<Delta> wrapper = new RemoteResultWrapper<>(delta, "Git Delta");
+        try (RevWalk walk = new RevWalk(repository)) {
+            RevCommit currentCommit = walk.parseCommit(ObjectId.fromString(currentCommitId));
+            RevCommit referenceCommit = walk.parseCommit(ObjectId.fromString(referenceCommitId));
 
-        RevWalk walk = new RevWalk(repository);
+            ByteArrayOutputStream diffStream = new ByteArrayOutputStream();
 
-        RevCommit currentCommit = walk.parseCommit(ObjectId.fromString(currentCommitId));
-        RevCommit referenceCommit = walk.parseCommit(ObjectId.fromString(referenceCommitId));
+            FilteredLog log = new FilteredLog("Errors from Git Delta:");
+            log.logInfo("Start scanning for differences between commits...");
 
-        ByteArrayOutputStream diffStream = new ByteArrayOutputStream();
+            try (DiffFormatter diffFormatter = new DiffFormatter(diffStream)) {
+                diffFormatter.setDiffComparator(RawTextComparator.WS_IGNORE_ALL);
+                diffFormatter.setRepository(repository);
 
-        wrapper.logInfo("Start scanning for differences between commits...");
+                final List<DiffEntry> diffEntries = diffFormatter.scan(referenceCommit, currentCommit);
+                final Map<String, FileChanges> fileChangesMap = new HashMap<>();
 
-        try (DiffFormatter diffFormatter = new DiffFormatter(diffStream)) {
-            diffFormatter.setDiffComparator(RawTextComparator.WS_IGNORE_ALL);
-            diffFormatter.setRepository(repository);
+                log.logInfo("%d files contain changes", diffEntries.size());
 
-            final List<DiffEntry> diffEntries = diffFormatter.scan(referenceCommit, currentCommit);
-            final Map<String, FileChanges> fileChangesMap = new HashMap<>();
-
-            wrapper.logInfo("%d files contain changes", diffEntries.size());
-
-            for (DiffEntry diffEntry : diffEntries) {
-                String filePath = diffEntry.getNewPath();
-                String fileContent;
-                FileEditType fileEditType = getFileEditType(diffEntry.getChangeType());
-                if (fileEditType == FileEditType.UNDEFINED) {
-                    // this case should not happen when using JGIT since the types are well defined
-                    wrapper.logError("The file edit type of the file '%s' is undefined -> skip", filePath);
-                    continue;
-                }
-                else if (fileEditType == FileEditType.DELETE) {
-                    // file path and content of deleted files have to be read using old ID
-                    filePath = diffEntry.getOldPath();
-                    fileContent = getFileContent(diffEntry.getOldId().toObjectId(), repository);
-                }
-                else {
-                    fileContent = getFileContent(diffEntry.getNewId().toObjectId(), repository);
+                for (DiffEntry diffEntry : diffEntries) {
+                    FileEditType fileEditType = getFileEditType(diffEntry.getChangeType());
+                    FileChanges fileChanges = createFileChanges(fileEditType, diffEntry, diffFormatter, repository);
+                    fileChangesMap.put(diffEntry.getNewId().name(), fileChanges);
                 }
 
-                diffFormatter.format(diffEntry);
+                String diffFile = new String(diffStream.toByteArray(), StandardCharsets.UTF_8);
 
-                Map<ChangeEditType, List<Change>> changesByType = new HashMap<>();
-                FileChanges fileChanges = new FileChanges(filePath, fileContent, fileEditType, changesByType);
-                for (Edit edit : diffFormatter.toFileHeader(diffEntry).toEditList()) {
-                    addChangeByType(edit, changesByType);
-                }
+                GitDelta delta = new GitDelta(currentCommitId, referenceCommitId, fileChangesMap, diffFile);
+                RemoteResultWrapper<Delta> wrapper = new RemoteResultWrapper<>(delta, "Errors from Git Delta:");
+                wrapper.merge(log);
 
-                fileChangesMap.put(diffEntry.getNewId().name(), fileChanges);
+                return wrapper;
             }
+        }
+    }
 
-            String diffFile = new String(diffStream.toByteArray(), StandardCharsets.UTF_8);
-            delta.setDiffFile(diffFile);
-            delta.setFileChanges(fileChangesMap);
+    /**
+     * Creates an instance of {@link FileChanges} which wraps the information about all changes made to a specific
+     * file.
+     *
+     * @param fileEditType
+     *         The type which shows how the file has been affected
+     * @param diffEntry
+     *         The wrapper created by Git which contains the made changes to a specific file
+     * @param diffFormatter
+     *         The Git formatter for a patch script
+     * @param repository
+     *         The Git repository
+     *
+     * @return the information about changes made to a specific file
+     * @throws IOException
+     *         if accessing Git resources failed
+     */
+    private FileChanges createFileChanges(final FileEditType fileEditType, final DiffEntry diffEntry,
+            final DiffFormatter diffFormatter, final Repository repository)
+            throws IOException {
+        String filePath;
+        String fileContent;
+        if (fileEditType == FileEditType.DELETE) {
+            // file path and content of deleted files have to be read using old ID
+            filePath = diffEntry.getOldPath();
+            fileContent = getFileContent(diffEntry.getOldId().toObjectId(), repository);
+        }
+        else {
+            filePath = diffEntry.getNewPath();
+            fileContent = getFileContent(diffEntry.getNewId().toObjectId(), repository);
         }
 
-        return wrapper;
+        diffFormatter.format(diffEntry);
+
+        FileChanges fileChanges = new FileChanges(filePath, fileContent, fileEditType, new HashMap<>());
+
+        for (Edit edit : diffFormatter.toFileHeader(diffEntry).toEditList()) {
+            Change change = createChange(edit);
+            fileChanges.addChange(change);
+        }
+
+        return fileChanges;
     }
 
     /**
      * Reads the content of a file which is specified by its id - the {@link ObjectId}.
      *
-     * @param fileId     The file id
-     * @param repository The Git repository
+     * @param fileId
+     *         The file id
+     * @param repository
+     *         The Git repository
+     *
      * @return the file content
-     * @throws IOException if reading failed
+     * @throws IOException
+     *         if reading failed
      */
     private String getFileContent(final ObjectId fileId, final Repository repository) throws IOException {
         ObjectDatabase objectDatabase = repository.getObjectDatabase();
         ObjectLoader objectLoader = objectDatabase.open(fileId);
-        return new String(objectLoader.getBytes(), StandardCharsets.UTF_8);
+        return new String(objectLoader.getCachedBytes(), StandardCharsets.UTF_8);
     }
 
     /**
      * Transforms the Git specific {@link ChangeType} to the general model {@link FileEditType}.
      *
-     * @param type The Git specific change type
+     * @param type
+     *         The Git specific change type
+     *
      * @return the transformed general type
      */
     private FileEditType getFileEditType(final ChangeType type) {
@@ -160,14 +199,16 @@ public class DeltaRepositoryCallback extends AbstractRepositoryCallback<RemoteRe
             case COPY:
                 return FileEditType.COPY;
             default:
-                return FileEditType.UNDEFINED;
+                throw new IllegalArgumentException(String.format(ERROR_MESSAGE_UNKNOWN_FILE_EDIT_TYPE, type));
         }
     }
 
     /**
      * Transforms the Git specific {@link Edit.Type} to the general model {@link ChangeEditType}.
      *
-     * @param type The Git specific edit type
+     * @param type
+     *         The Git specific edit type
+     *
      * @return the transformed general type
      */
     private ChangeEditType getChangeEditType(final Edit.Type type) {
@@ -181,40 +222,29 @@ public class DeltaRepositoryCallback extends AbstractRepositoryCallback<RemoteRe
             case EMPTY:
                 return ChangeEditType.EMPTY;
             default:
-                return ChangeEditType.UNDEFINED;
+                throw new IllegalArgumentException(String.format(ERROR_MESSAGE_UNKNOWN_CHANGE_TYPE, type));
         }
     }
 
     /**
-     * Processes an edit on a file and adds it to a map which key are the {@link ChangeEditType}.
+     * Processes an edit on a file and returns a {@link Change} which wraps the information about this edit.
      *
-     * @param edit          The edit to be processed
-     * @param changesByType The map to which edits are added to after processing
+     * @param edit
+     *         The edit to be processed
+     *
+     * @return the created change
      */
-    private void addChangeByType(final Edit edit, final Map<ChangeEditType, List<Change>> changesByType) {
+    private Change createChange(final Edit edit) {
         ChangeEditType changeEditType = getChangeEditType(edit.getType());
-        if (changeEditType == ChangeEditType.UNDEFINED) {
-            return;
-        }
-        Change change;
         // add 1 to the 'begin' since it is included and the index is zero based
         // 'end' does not need this because the value is excluded anyway
         if (changeEditType == ChangeEditType.DELETE) {
             // get the changed line indices from the old file version
-            change = new Change(changeEditType, edit.getBeginA() + 1, edit.getEndA());
+            return new Change(changeEditType, edit.getBeginA() + 1, edit.getEndA());
         }
         else {
             // get the changed line indices from the new file version
-            change = new Change(changeEditType, edit.getBeginB() + 1, edit.getEndB());
-        }
-
-        if (changesByType.containsKey(changeEditType)) {
-            changesByType.get(changeEditType).add(change);
-        }
-        else {
-            List<Change> changes = new ArrayList<>();
-            changes.add(change);
-            changesByType.put(changeEditType, changes);
+            return new Change(changeEditType, edit.getBeginB() + 1, edit.getEndB());
         }
     }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/DeltaRepositoryCallback.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/DeltaRepositoryCallback.java
@@ -1,0 +1,225 @@
+package io.jenkins.plugins.forensics.git.delta;
+
+import hudson.remoting.VirtualChannel;
+import io.jenkins.plugins.forensics.delta.model.*;
+import io.jenkins.plugins.forensics.git.util.AbstractRepositoryCallback;
+import io.jenkins.plugins.forensics.git.util.RemoteResultWrapper;
+import org.eclipse.jgit.diff.DiffEntry;
+import org.eclipse.jgit.diff.DiffEntry.ChangeType;
+import org.eclipse.jgit.diff.DiffFormatter;
+import org.eclipse.jgit.diff.Edit;
+import org.eclipse.jgit.diff.RawTextComparator;
+import org.eclipse.jgit.lib.ObjectDatabase;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectLoader;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Repository callback that calculates the code difference - so called 'delta' - between two commits.
+ *
+ * @author Florian Orendi
+ */
+public class DeltaRepositoryCallback extends AbstractRepositoryCallback<RemoteResultWrapper<Delta>> {
+
+    private static final long serialVersionUID = -4561284338216569043L;
+
+    /**
+     * The currently processed commit.
+     */
+    private final String currentCommitId;
+    /**
+     * The reference commit to calculate the delta to.
+     */
+    private final String referenceCommitId;
+
+    public DeltaRepositoryCallback(final String currentCommitId, final String referenceCommitId) {
+        this.currentCommitId = currentCommitId;
+        this.referenceCommitId = referenceCommitId;
+    }
+
+    @Override
+    public RemoteResultWrapper<Delta> invoke(final Repository repository, final VirtualChannel channel)
+            throws IOException {
+        return calculateDelta(repository);
+    }
+
+    /**
+     * Calculates the delta between the commits {@link #currentCommitId} and {@link #referenceCommitId} by using the Git
+     * repository.
+     *
+     * @param repository
+     *         The Git repository.
+     *
+     * @return a serializable wrapper containing the delta
+     * @throws IOException
+     *         if communicating with Git failed
+     */
+    private RemoteResultWrapper<Delta> calculateDelta(final Repository repository) throws IOException {
+        Delta delta = new Delta(currentCommitId, referenceCommitId);
+        RemoteResultWrapper<Delta> wrapper = new RemoteResultWrapper<>(delta, "Git Delta");
+
+        RevWalk walk = new RevWalk(repository);
+
+        RevCommit currentCommit = walk.parseCommit(ObjectId.fromString(currentCommitId));
+        RevCommit referenceCommit = walk.parseCommit(ObjectId.fromString(referenceCommitId));
+
+        ByteArrayOutputStream diffStream = new ByteArrayOutputStream();
+
+        wrapper.logInfo("Start scanning for differences between commits...");
+
+        try (DiffFormatter diffFormatter = new DiffFormatter(diffStream)) {
+            diffFormatter.setDiffComparator(RawTextComparator.WS_IGNORE_ALL);
+            diffFormatter.setRepository(repository);
+
+            final List<DiffEntry> diffEntries = diffFormatter.scan(referenceCommit, currentCommit);
+            final Map<String, FileChanges> fileChangesMap = new HashMap<>();
+
+            wrapper.logInfo("%d files contain changes", diffEntries.size());
+
+            for (DiffEntry diffEntry : diffEntries) {
+                String filePath = diffEntry.getNewPath();
+                String fileContent;
+                FileEditType fileEditType = getFileEditType(diffEntry.getChangeType());
+                if (fileEditType == FileEditType.UNDEFINED) {
+                    // this case should not happen when using JGIT since the types are well defined
+                    wrapper.logError("The file edit type of the file '%s' is undefined -> skip", filePath);
+                    continue;
+                }
+                else if (fileEditType == FileEditType.DELETE) {
+                    // file path and content of deleted files have to be read using old ID
+                    filePath = diffEntry.getOldPath();
+                    fileContent = getFileContent(diffEntry.getOldId().toObjectId(), repository);
+                }
+                else {
+                    fileContent = getFileContent(diffEntry.getNewId().toObjectId(), repository);
+                }
+
+                diffFormatter.format(diffEntry);
+
+                Map<ChangeEditType, List<Change>> changesByType = new HashMap<>();
+                FileChanges fileChanges = new FileChanges(filePath, fileContent, fileEditType, changesByType);
+                for (Edit edit : diffFormatter.toFileHeader(diffEntry).toEditList()) {
+                    addChangeByType(edit, changesByType);
+                }
+
+                fileChangesMap.put(diffEntry.getNewId().name(), fileChanges);
+            }
+
+            String diffFile = diffStream.toString();
+            delta.setDiffFile(diffFile);
+            delta.setFileChanges(fileChangesMap);
+        }
+
+        return wrapper;
+    }
+
+    /**
+     * Reads the content of a file which is specified by its id - the {@link ObjectId}.
+     *
+     * @param fileId
+     *         The file id
+     * @param repository
+     *         The Git repository
+     *
+     * @return the file content
+     * @throws IOException
+     *         if reading failed
+     */
+    private String getFileContent(final ObjectId fileId, final Repository repository) throws IOException {
+        ObjectDatabase objectDatabase = repository.getObjectDatabase();
+        ObjectLoader objectLoader = objectDatabase.open(fileId);
+        return new String(objectLoader.getBytes());
+    }
+
+    /**
+     * Transforms the Git specific {@link ChangeType} to the general model {@link FileEditType}.
+     *
+     * @param type
+     *         The Git specific change type
+     *
+     * @return the transformed general type
+     */
+    private FileEditType getFileEditType(final ChangeType type) {
+        switch (type) {
+            case ADD:
+                return FileEditType.ADD;
+            case DELETE:
+                return FileEditType.DELETE;
+            case MODIFY:
+                return FileEditType.MODIFY;
+            case RENAME:
+                return FileEditType.RENAME;
+            case COPY:
+                return FileEditType.COPY;
+            default:
+                return FileEditType.UNDEFINED;
+        }
+    }
+
+    /**
+     * Transforms the Git specific {@link Edit.Type} to the general model {@link ChangeEditType}.
+     *
+     * @param type
+     *         The Git specific edit type
+     *
+     * @return the transformed general type
+     */
+    private ChangeEditType getChangeEditType(final Edit.Type type) {
+        switch (type) {
+            case INSERT:
+                return ChangeEditType.INSERT;
+            case DELETE:
+                return ChangeEditType.DELETE;
+            case REPLACE:
+                return ChangeEditType.REPLACE;
+            case EMPTY:
+                return ChangeEditType.EMPTY;
+            default:
+                return ChangeEditType.UNDEFINED;
+        }
+    }
+
+    /**
+     * Processes an edit on a file and adds it to a map which key are the {@link ChangeEditType}.
+     *
+     * @param edit
+     *         The edit to be processed
+     * @param changesByType
+     *         The map to which edits are added to after processing
+     */
+    private void addChangeByType(final Edit edit, final Map<ChangeEditType, List<Change>> changesByType) {
+        ChangeEditType changeEditType = getChangeEditType(edit.getType());
+        if (changeEditType == ChangeEditType.UNDEFINED) {
+            return;
+        }
+        Change change;
+        // add 1 to the 'begin' since it is included and the index is zero based
+        // 'end' does not need this because the value is excluded anyway
+        if (changeEditType == ChangeEditType.DELETE) {
+            // get the changed line indices from the old file version
+            change = new Change(changeEditType, edit.getBeginA() + 1, edit.getEndA());
+        }
+        else {
+            // get the changed line indices from the new file version
+            change = new Change(changeEditType, edit.getBeginB() + 1, edit.getEndB());
+        }
+
+        if (changesByType.containsKey(changeEditType)) {
+            changesByType.get(changeEditType).add(change);
+        }
+        else {
+            List<Change> changes = new ArrayList<>();
+            changes.add(change);
+            changesByType.put(changeEditType, changes);
+        }
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculator.java
@@ -1,0 +1,58 @@
+package io.jenkins.plugins.forensics.git.delta;
+
+import edu.hm.hafner.util.FilteredLog;
+import io.jenkins.plugins.forensics.delta.DeltaCalculator;
+import io.jenkins.plugins.forensics.delta.model.Delta;
+import io.jenkins.plugins.forensics.git.util.RemoteResultWrapper;
+import org.jenkinsci.plugins.gitclient.GitClient;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * A {@link DeltaCalculator} for Git.
+ *
+ * @author Florian Orendi
+ */
+public class GitDeltaCalculator extends DeltaCalculator {
+
+    /**
+     * Error message when calculating the delta failed.
+     */
+    static final String DELTA_ERROR = "Computing delta information failed with an exception:";
+
+    private static final long serialVersionUID = -7303579046266608368L;
+
+    /**
+     * The used Git client.
+     */
+    private final GitClient git;
+
+    public GitDeltaCalculator(final GitClient git) {
+        super();
+        this.git = git;
+    }
+
+    @Override
+    public Optional<Delta> calculateDelta(final String currentCommit, final String referenceCommit,
+            final FilteredLog log) {
+        try {
+            log.logInfo("Invoking Git delta calculator for determining the made changes between the commits with the IDs %s and %s",
+                    currentCommit, referenceCommit);
+
+            if (currentCommit != null && !currentCommit.isEmpty() && referenceCommit != null
+                    && !referenceCommit.isEmpty()) {
+                RemoteResultWrapper<Delta> wrapped = git.withRepository(
+                        new DeltaRepositoryCallback(currentCommit, referenceCommit));
+                wrapped.getInfoMessages().forEach(log::logInfo);
+
+                return Optional.of(wrapped.getResult());
+            }
+        }
+        catch (IOException | InterruptedException exception) {
+            log.logException(exception, DELTA_ERROR);
+        }
+
+        return Optional.empty();
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculator.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.forensics.git.delta;
 
 import edu.hm.hafner.util.FilteredLog;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jenkins.plugins.forensics.delta.DeltaCalculator;
 import io.jenkins.plugins.forensics.delta.model.Delta;
 import io.jenkins.plugins.forensics.git.util.RemoteResultWrapper;
@@ -14,6 +15,7 @@ import java.util.Optional;
  *
  * @author Florian Orendi
  */
+@SuppressFBWarnings(value = "SE", justification = "GitClient implementation is Serializable")
 public class GitDeltaCalculator extends DeltaCalculator {
 
     /**
@@ -28,6 +30,11 @@ public class GitDeltaCalculator extends DeltaCalculator {
      */
     private final GitClient git;
 
+    /**
+     * Constructor for an instance of {@link DeltaCalculator} which can be used for Git.
+     *
+     * @param git The {@link GitClient}
+     */
     public GitDeltaCalculator(final GitClient git) {
         super();
         this.git = git;

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculator.java
@@ -35,7 +35,7 @@ public class GitDeltaCalculator extends DeltaCalculator {
 
     @Override
     public Optional<Delta> calculateDelta(final String currentCommit, final String referenceCommit,
-            final FilteredLog log) {
+                                          final FilteredLog log) {
         try {
             log.logInfo("Invoking Git delta calculator for determining the made changes between the commits with the IDs %s and %s",
                     currentCommit, referenceCommit);

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculator.java
@@ -2,9 +2,9 @@ package io.jenkins.plugins.forensics.git.delta;
 
 import java.io.IOException;
 import java.util.Optional;
-import javax.annotation.Nonnull;
 
 import edu.hm.hafner.util.FilteredLog;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import org.jenkinsci.plugins.gitclient.GitClient;
@@ -39,8 +39,8 @@ public class GitDeltaCalculator extends DeltaCalculator {
     }
 
     @Override
-    public Optional<Delta> calculateDelta(@Nonnull final String currentCommit, @Nonnull final String referenceCommit,
-            @Nonnull final FilteredLog log) {
+    public Optional<Delta> calculateDelta(@NonNull final String currentCommit, @NonNull final String referenceCommit,
+            @NonNull final FilteredLog log) {
         try {
             log.logInfo(
                     "Invoking Git delta calculator for determining the made changes between the commits with the IDs %s and %s",

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculator.java
@@ -1,14 +1,17 @@
 package io.jenkins.plugins.forensics.git.delta;
 
+import java.io.IOException;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+
 import edu.hm.hafner.util.FilteredLog;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import org.jenkinsci.plugins.gitclient.GitClient;
+
 import io.jenkins.plugins.forensics.delta.DeltaCalculator;
 import io.jenkins.plugins.forensics.delta.model.Delta;
 import io.jenkins.plugins.forensics.git.util.RemoteResultWrapper;
-import org.jenkinsci.plugins.gitclient.GitClient;
-
-import java.io.IOException;
-import java.util.Optional;
 
 /**
  * A {@link DeltaCalculator} for Git.
@@ -18,22 +21,17 @@ import java.util.Optional;
 @SuppressFBWarnings(value = "SE", justification = "GitClient implementation is Serializable")
 public class GitDeltaCalculator extends DeltaCalculator {
 
-    /**
-     * Error message when calculating the delta failed.
-     */
     static final String DELTA_ERROR = "Computing delta information failed with an exception:";
 
     private static final long serialVersionUID = -7303579046266608368L;
 
-    /**
-     * The used Git client.
-     */
     private final GitClient git;
 
     /**
      * Constructor for an instance of {@link DeltaCalculator} which can be used for Git.
      *
-     * @param git The {@link GitClient}
+     * @param git
+     *         The {@link GitClient}
      */
     public GitDeltaCalculator(final GitClient git) {
         super();
@@ -41,14 +39,14 @@ public class GitDeltaCalculator extends DeltaCalculator {
     }
 
     @Override
-    public Optional<Delta> calculateDelta(final String currentCommit, final String referenceCommit,
-                                          final FilteredLog log) {
+    public Optional<Delta> calculateDelta(@Nonnull final String currentCommit, @Nonnull final String referenceCommit,
+            @Nonnull final FilteredLog log) {
         try {
-            log.logInfo("Invoking Git delta calculator for determining the made changes between the commits with the IDs %s and %s",
+            log.logInfo(
+                    "Invoking Git delta calculator for determining the made changes between the commits with the IDs %s and %s",
                     currentCommit, referenceCommit);
 
-            if (currentCommit != null && !currentCommit.isEmpty() && referenceCommit != null
-                    && !referenceCommit.isEmpty()) {
+            if (!currentCommit.isEmpty() && !referenceCommit.isEmpty()) {
                 RemoteResultWrapper<Delta> wrapped = git.withRepository(
                         new DeltaRepositoryCallback(currentCommit, referenceCommit));
                 wrapped.getInfoMessages().forEach(log::logInfo);

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorFactory.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorFactory.java
@@ -1,0 +1,37 @@
+package io.jenkins.plugins.forensics.git.delta;
+
+import edu.hm.hafner.util.FilteredLog;
+import edu.hm.hafner.util.PathUtil;
+import hudson.FilePath;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.scm.SCM;
+import io.jenkins.plugins.forensics.delta.DeltaCalculator;
+import io.jenkins.plugins.forensics.delta.DeltaCalculatorFactory;
+import io.jenkins.plugins.forensics.git.util.GitRepositoryValidator;
+import org.jenkinsci.plugins.gitclient.GitClient;
+
+import java.util.Optional;
+
+/**
+ * A {@link DeltaCalculatorFactory} for Git.
+ *
+ * @author Florian Orendi
+ */
+public class GitDeltaCalculatorFactory extends DeltaCalculatorFactory {
+
+    @Override
+    public Optional<DeltaCalculator> createDeltaCalculator(final SCM scm, final Run<?, ?> run, final FilePath workspace,
+            final TaskListener listener, final FilteredLog logger) {
+        GitRepositoryValidator validator = new GitRepositoryValidator(scm, run, workspace, listener, logger);
+        if (validator.isGitRepository()) {
+            GitClient client = validator.createClient();
+            logger.logInfo("-> Git delta calculator successfully created in working tree '%s'",
+                    new PathUtil().getAbsolutePath(client.getWorkTree().getRemote()));
+            return Optional.of(new GitDeltaCalculator(client));
+        }
+        logger.logInfo("-> Git Delta Calculator could not be created for SCM '%s' in working tree '%s'", scm,
+                workspace);
+        return Optional.empty();
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorFactory.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorFactory.java
@@ -22,7 +22,7 @@ public class GitDeltaCalculatorFactory extends DeltaCalculatorFactory {
 
     @Override
     public Optional<DeltaCalculator> createDeltaCalculator(final SCM scm, final Run<?, ?> run, final FilePath workspace,
-            final TaskListener listener, final FilteredLog logger) {
+                                                           final TaskListener listener, final FilteredLog logger) {
         GitRepositoryValidator validator = new GitRepositoryValidator(scm, run, workspace, listener, logger);
         if (validator.isGitRepository()) {
             GitClient client = validator.createClient();

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorFactory.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorFactory.java
@@ -1,17 +1,19 @@
 package io.jenkins.plugins.forensics.git.delta;
 
+import java.util.Optional;
+
 import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.PathUtil;
+
+import org.jenkinsci.plugins.gitclient.GitClient;
 import hudson.FilePath;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.scm.SCM;
+
 import io.jenkins.plugins.forensics.delta.DeltaCalculator;
 import io.jenkins.plugins.forensics.delta.DeltaCalculatorFactory;
 import io.jenkins.plugins.forensics.git.util.GitRepositoryValidator;
-import org.jenkinsci.plugins.gitclient.GitClient;
-
-import java.util.Optional;
 
 /**
  * A {@link DeltaCalculatorFactory} for Git.
@@ -22,7 +24,7 @@ public class GitDeltaCalculatorFactory extends DeltaCalculatorFactory {
 
     @Override
     public Optional<DeltaCalculator> createDeltaCalculator(final SCM scm, final Run<?, ?> run, final FilePath workspace,
-                                                           final TaskListener listener, final FilteredLog logger) {
+            final TaskListener listener, final FilteredLog logger) {
         GitRepositoryValidator validator = new GitRepositoryValidator(scm, run, workspace, listener, logger);
         if (validator.isGitRepository()) {
             GitClient client = validator.createClient();

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/model/GitDelta.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/model/GitDelta.java
@@ -1,0 +1,64 @@
+package io.jenkins.plugins.forensics.git.delta.model;
+
+import java.util.Map;
+import java.util.Objects;
+
+import io.jenkins.plugins.forensics.delta.model.Delta;
+import io.jenkins.plugins.forensics.delta.model.FileChanges;
+
+/**
+ * A Git specific extension of {@link Delta}.
+ *
+ * @author Florian Orendi
+ */
+public class GitDelta extends Delta {
+
+    private static final long serialVersionUID = 4075956106966630282L;
+
+    /**
+     * The Diff-File which has been created by Git and wraps up all made changes between two commits.
+     */
+    private final String diffFile;
+
+    /**
+     * Constructor for a delta instance which wraps code changes between the two passed commits.
+     *
+     * @param currentCommit
+     *         The currently processed commit
+     * @param referenceCommit
+     *         The reference commit
+     * @param fileChanges
+     *         The map which contains the changes for modified files, mapped by the file ID.
+     * @param diffFile
+     *         The Diff-File which has been created by Git and wraps up all made changes between two commits.
+     */
+    public GitDelta(final String currentCommit, final String referenceCommit,
+            final Map<String, FileChanges> fileChanges, final String diffFile) {
+        super(currentCommit, referenceCommit, fileChanges);
+        this.diffFile = diffFile;
+    }
+
+    public String getDiffFile() {
+        return diffFile;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        GitDelta gitDelta = (GitDelta) o;
+        return Objects.equals(diffFile, gitDelta.diffFile);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), diffFile);
+    }
+}

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/model/package-info.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/model/package-info.java
@@ -1,10 +1,10 @@
 /**
- * Git implementation for determining the code difference - so called 'delta' - between two commits.
+ * Contains Git specific adjustments of the model, which represents the calculated code delta.
  *
  * @author Florian Orendi
  */
 @DefaultAnnotation(NonNull.class)
-package io.jenkins.plugins.forensics.git.delta;
+package io.jenkins.plugins.forensics.git.delta.model;
 
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/package-info.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/delta/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Git implementation for determining the code difference - so called 'delta' - between two commits.
+ *
+ * @author Florian Orendi
+ */
+package io.jenkins.plugins.forensics.git.delta;

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorFactoryTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorFactoryTest.java
@@ -1,0 +1,124 @@
+package io.jenkins.plugins.forensics.git.delta;
+
+import edu.hm.hafner.util.FilteredLog;
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.model.Run;
+import hudson.model.Saveable;
+import hudson.model.TaskListener;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.extensions.impl.CloneOption;
+import hudson.scm.NullSCM;
+import hudson.util.DescribableList;
+import io.jenkins.plugins.forensics.delta.DeltaCalculator;
+import io.jenkins.plugins.forensics.git.util.GitRepositoryValidator;
+import org.assertj.core.util.Lists;
+import org.eclipse.jgit.lib.ObjectId;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Integration test for the class {@link GitDeltaCalculatorFactory}.
+ *
+ * @author Florian Orendi
+ */
+class GitDeltaCalculatorFactoryTest {
+
+    private static final TaskListener NULL_LISTENER = TaskListener.NULL;
+
+    @Test
+    void shouldSkipIfScmIsNotGit() {
+        FilteredLog logger = createLogger();
+
+        GitDeltaCalculatorFactory factory = new GitDeltaCalculatorFactory();
+
+        assertThat(factory.createDeltaCalculator(new NullSCM(), null, null, NULL_LISTENER, logger)).isEmpty();
+        assertThat(logger.getErrorMessages()).isEmpty();
+        assertThat(logger.getInfoMessages()).contains("SCM 'hudson.scm.NullSCM' is not of type GitSCM");
+    }
+
+    @Test
+    void shouldCreateDeltaCalculatorForGit() throws IOException, InterruptedException {
+        GitSCM gitSCM = createGitScm();
+
+        Run<?, ?> run = mock(Run.class);
+
+        EnvVars envVars = new EnvVars();
+        when(run.getEnvironment(NULL_LISTENER)).thenReturn(envVars);
+
+        GitClient gitClient = mock(GitClient.class);
+        FilePath workspace = createWorkTreeStub();
+        ObjectId commit = mock(ObjectId.class);
+        when(gitClient.revParse(anyString())).thenReturn(commit);
+        when(gitClient.getWorkTree()).thenReturn(new FilePath(new File("/working-tree")));
+
+        when(gitSCM.createClient(NULL_LISTENER, envVars, run, workspace)).thenReturn(gitClient);
+        FilteredLog logger = createLogger();
+
+        GitDeltaCalculatorFactory factory = new GitDeltaCalculatorFactory();
+        Optional<DeltaCalculator> deltaCalculator = factory.createDeltaCalculator(gitSCM, run, workspace, NULL_LISTENER,
+                logger);
+
+        assertThat(deltaCalculator).isNotEmpty().containsInstanceOf(GitDeltaCalculator.class);
+        assertThat(logger.getErrorMessages()).isEmpty();
+        assertThat(logger.getInfoMessages()).contains(
+                "-> Git delta calculator successfully created in working tree '/working-tree'");
+    }
+
+    @Test
+    void shouldCreateNullDeltaCalculatorOnShallowGit() {
+        CloneOption shallowCloneOption = mock(CloneOption.class);
+        when(shallowCloneOption.isShallow()).thenReturn(true);
+
+        GitSCM git = mock(GitSCM.class);
+        when(git.getExtensions()).thenReturn(new DescribableList<>(Saveable.NOOP, Lists.list(shallowCloneOption)));
+
+        FilteredLog logger = createLogger();
+
+        GitDeltaCalculatorFactory factory = new GitDeltaCalculatorFactory();
+
+        assertThat(factory.createDeltaCalculator(git, mock(Run.class), null, NULL_LISTENER, logger)).isEmpty();
+        assertThat(logger.getInfoMessages()).contains(GitRepositoryValidator.INFO_SHALLOW_CLONE);
+        assertThat(logger.getErrorMessages()).isEmpty();
+    }
+
+    @Test
+    void shouldCreateNullDeltaCalculatorOnError() throws IOException, InterruptedException {
+        GitDeltaCalculatorFactory factory = new GitDeltaCalculatorFactory();
+
+        Run<?, ?> run = mock(Run.class);
+        when(run.getEnvironment(NULL_LISTENER)).thenThrow(new IOException());
+
+        FilteredLog logger = createLogger();
+
+        assertThat(factory.createDeltaCalculator(createGitScm(), run, null, NULL_LISTENER, logger)).isEmpty();
+        assertThat(logger.getErrorMessages()).isEmpty();
+        assertThat(logger.getInfoMessages()).contains(
+                "Exception while creating a GitClient instance for work tree 'null'");
+    }
+
+    private FilePath createWorkTreeStub() {
+        File mock = mock(File.class);
+        when(mock.getPath()).thenReturn("/");
+        return new FilePath(mock);
+    }
+
+    private GitSCM createGitScm() {
+        GitSCM git = mock(GitSCM.class);
+        when(git.getExtensions()).thenReturn(new DescribableList<>(Saveable.NOOP));
+        return git;
+    }
+
+    private FilteredLog createLogger() {
+        return new FilteredLog("errors");
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorFactoryTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorFactoryTest.java
@@ -1,6 +1,16 @@
 package io.jenkins.plugins.forensics.git.delta;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+
+import org.assertj.core.util.Lists;
+import org.eclipse.jgit.lib.ObjectId;
+import org.junit.jupiter.api.Test;
+
 import edu.hm.hafner.util.FilteredLog;
+
+import org.jenkinsci.plugins.gitclient.GitClient;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.Run;
@@ -10,21 +20,13 @@ import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.extensions.impl.CloneOption;
 import hudson.scm.NullSCM;
 import hudson.util.DescribableList;
+
 import io.jenkins.plugins.forensics.delta.DeltaCalculator;
 import io.jenkins.plugins.forensics.git.util.GitRepositoryValidator;
-import org.assertj.core.util.Lists;
-import org.eclipse.jgit.lib.ObjectId;
-import org.jenkinsci.plugins.gitclient.GitClient;
-import org.junit.jupiter.api.Test;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Integration test for the class {@link GitDeltaCalculatorFactory}.

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorITest.java
@@ -1,7 +1,6 @@
 package io.jenkins.plugins.forensics.git.delta;
 
 import edu.hm.hafner.util.FilteredLog;
-import io.jenkins.plugins.forensics.assertions.Assertions;
 import io.jenkins.plugins.forensics.delta.model.*;
 import io.jenkins.plugins.forensics.git.util.GitITest;
 import org.apache.commons.lang3.StringUtils;
@@ -10,7 +9,7 @@ import org.junit.Test;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static io.jenkins.plugins.forensics.assertions.Assertions.assertThat;
 
 /**
  * Integration test for the class {@link GitDeltaCalculator}.
@@ -19,8 +18,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class GitDeltaCalculatorITest extends GitITest {
 
+    /**
+     * The delta result should be empty if there are invalid commits.
+     */
     @Test
-    public void shouldCreateEmptyDeltaIfCommitsAreEmpty() {
+    public void shouldCreateEmptyDeltaIfCommitsAreInvalid() {
         GitDeltaCalculator deltaCalculator = createDeltaCalculator();
 
         FilteredLog log = createLog();
@@ -29,6 +31,9 @@ public class GitDeltaCalculatorITest extends GitITest {
         assertThat(delta).isEmpty();
     }
 
+    /**
+     * The commit boundaries should be set properly.
+     */
     @Test
     public void shouldSetCommitBoundaries() {
         GitDeltaCalculator deltaCalculator = createDeltaCalculator();
@@ -42,10 +47,13 @@ public class GitDeltaCalculatorITest extends GitITest {
         assertThat(result).isNotEmpty();
 
         Delta delta = result.get();
-        Assertions.assertThat(delta).hasCurrentCommit(currentCommit);
-        Assertions.assertThat(delta).hasReferenceCommit(referenceCommit);
+        assertThat(delta).hasCurrentCommit(currentCommit);
+        assertThat(delta).hasReferenceCommit(referenceCommit);
     }
 
+    /**
+     * The Git diff file should be created properly.
+     */
     @Test
     public void shouldCreateDiffFile() {
         GitDeltaCalculator deltaCalculator = createDeltaCalculator();
@@ -63,7 +71,7 @@ public class GitDeltaCalculatorITest extends GitITest {
         assertThat(result).isNotEmpty();
 
         Delta delta = result.get();
-        Assertions.assertThat(delta).hasDiffFile("diff --git a/newFile b/newFile\n"
+        assertThat(delta).hasDiffFile("diff --git a/newFile b/newFile\n"
                 + "new file mode 100644\n"
                 + "index 0000000..6b584e8\n"
                 + "--- /dev/null\n"
@@ -73,6 +81,9 @@ public class GitDeltaCalculatorITest extends GitITest {
                 + "\\ No newline at end of file\n");
     }
 
+    /**
+     * An added file should be determined.
+     */
     @Test
     public void shouldDetermineAddedFile() {
         GitDeltaCalculator deltaCalculator = createDeltaCalculator();
@@ -97,6 +108,9 @@ public class GitDeltaCalculatorITest extends GitITest {
         assertThat(fileChanges.getFileContent()).isEqualTo(content);
     }
 
+    /**
+     * A modified file should be determined.
+     */
     @Test
     public void shouldDetermineModifiedFile() {
         GitDeltaCalculator deltaCalculator = createDeltaCalculator();
@@ -118,6 +132,9 @@ public class GitDeltaCalculatorITest extends GitITest {
         assertThat(fileChanges.getFileContent()).isEqualTo(content);
     }
 
+    /**
+     * A deleted file should be determined.
+     */
     @Test
     public void shouldDetermineDeletedFile() {
         GitDeltaCalculator deltaCalculator = createDeltaCalculator();
@@ -140,6 +157,9 @@ public class GitDeltaCalculatorITest extends GitITest {
         assertThat(fileChanges.getFileContent()).isEqualTo(content);
     }
 
+    /**
+     * Added lines within a specific file should be determined.
+     */
     @Test
     public void shouldDetermineAddedLines() {
         GitDeltaCalculator deltaCalculator = createDeltaCalculator();
@@ -157,11 +177,14 @@ public class GitDeltaCalculatorITest extends GitITest {
         Delta delta = result.get();
         FileChanges fileChanges = getFileChanges(delta);
         Change change = getSingleChangeOfType(fileChanges, ChangeEditType.INSERT);
-        Assertions.assertThat(change.getEditType()).isEqualTo(ChangeEditType.INSERT);
+        assertThat(change.getEditType()).isEqualTo(ChangeEditType.INSERT);
         assertThat(change.getFromLine()).isEqualTo(3);
         assertThat(change.getToLine()).isEqualTo(4);
     }
 
+    /**
+     * Modified lines within a specific file should be determined.
+     */
     @Test
     public void shouldDetermineModifiedLines() {
         GitDeltaCalculator deltaCalculator = createDeltaCalculator();
@@ -180,11 +203,14 @@ public class GitDeltaCalculatorITest extends GitITest {
         Delta delta = result.get();
         FileChanges fileChanges = getFileChanges(delta);
         Change change = getSingleChangeOfType(fileChanges, ChangeEditType.REPLACE);
-        Assertions.assertThat(change.getEditType()).isEqualTo(ChangeEditType.REPLACE);
+        assertThat(change.getEditType()).isEqualTo(ChangeEditType.REPLACE);
         assertThat(change.getFromLine()).isEqualTo(2);
         assertThat(change.getToLine()).isEqualTo(2);
     }
 
+    /**
+     * Deleted lines within a specific file should be determined.
+     */
     @Test
     public void shouldDetermineDeletedLines() {
         GitDeltaCalculator deltaCalculator = createDeltaCalculator();
@@ -203,11 +229,14 @@ public class GitDeltaCalculatorITest extends GitITest {
         Delta delta = result.get();
         FileChanges fileChanges = getFileChanges(delta);
         Change change = getSingleChangeOfType(fileChanges, ChangeEditType.DELETE);
-        Assertions.assertThat(change.getEditType()).isEqualTo(ChangeEditType.DELETE);
+        assertThat(change.getEditType()).isEqualTo(ChangeEditType.DELETE);
         assertThat(change.getFromLine()).isEqualTo(2);
         assertThat(change.getToLine()).isEqualTo(2);
     }
 
+    /**
+     * Added, modified and deleted lines within a specific file should be determined properly together.
+     */
     @Test
     public void shouldDetermineAllChangeTypesTogether() {
         GitDeltaCalculator deltaCalculator = createDeltaCalculator();
@@ -227,21 +256,29 @@ public class GitDeltaCalculatorITest extends GitITest {
         FileChanges fileChanges = getFileChanges(delta);
 
         Change replace = getSingleChangeOfType(fileChanges, ChangeEditType.REPLACE);
-        Assertions.assertThat(replace.getEditType()).isEqualTo(ChangeEditType.REPLACE);
+        assertThat(replace.getEditType()).isEqualTo(ChangeEditType.REPLACE);
         assertThat(replace.getFromLine()).isEqualTo(1);
         assertThat(replace.getToLine()).isEqualTo(1);
 
         Change insert = getSingleChangeOfType(fileChanges, ChangeEditType.INSERT);
-        Assertions.assertThat(insert.getEditType()).isEqualTo(ChangeEditType.INSERT);
+        assertThat(insert.getEditType()).isEqualTo(ChangeEditType.INSERT);
         assertThat(insert.getFromLine()).isEqualTo(3);
         assertThat(insert.getToLine()).isEqualTo(3);
 
         Change delete = getSingleChangeOfType(fileChanges, ChangeEditType.DELETE);
-        Assertions.assertThat(delete.getEditType()).isEqualTo(ChangeEditType.DELETE);
+        assertThat(delete.getEditType()).isEqualTo(ChangeEditType.DELETE);
         assertThat(delete.getFromLine()).isEqualTo(4);
         assertThat(delete.getToLine()).isEqualTo(4);
     }
 
+    /**
+     * Gets the first {@link Change} of a specific {@link ChangeEditType} within a file when there is only a single change
+     * and checks if the found values are properly.
+     *
+     * @param fileChanges The changes within a file
+     * @param type        The change type
+     * @return the first found change
+     */
     private Change getSingleChangeOfType(final FileChanges fileChanges, final ChangeEditType type) {
         List<Change> changes = fileChanges.getChanges().get(type);
         assertThat(changes).isNotNull().isNotEmpty();
@@ -249,12 +286,23 @@ public class GitDeltaCalculatorITest extends GitITest {
         return changes.get(0);
     }
 
+    /**
+     * Gets the {@link FileChanges} of a calculated code {@link Delta}.
+     *
+     * @param delta The code delta
+     * @return the found changes.
+     */
     private FileChanges getFileChanges(final Delta delta) {
         Optional<FileChanges> fileChanges = delta.getFileChanges().values().stream().findFirst();
         assertThat(fileChanges).isNotEmpty();
         return fileChanges.get();
     }
 
+    /**
+     * Creates and commits a file with a fixed name and with the passed file content.
+     *
+     * @param content The file contend
+     */
     private void commitFile(final String content) {
         writeFile(INITIAL_FILE, content);
         git("add", INITIAL_FILE);
@@ -263,10 +311,20 @@ public class GitDeltaCalculatorITest extends GitITest {
         git("commit", "--message=Test");
     }
 
+    /**
+     * Creates a {@link FilteredLog}.
+     *
+     * @return the created log
+     */
     private FilteredLog createLog() {
         return new FilteredLog(StringUtils.EMPTY);
     }
 
+    /**
+     * Creates a {@link GitDeltaCalculator}.
+     *
+     * @return the created delta calculator
+     */
     private GitDeltaCalculator createDeltaCalculator() {
         return new GitDeltaCalculator(createGitClient());
     }

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorITest.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
 import edu.hm.hafner.util.FilteredLog;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import io.jenkins.plugins.forensics.delta.model.Change;
 import io.jenkins.plugins.forensics.delta.model.ChangeEditType;
@@ -43,6 +44,7 @@ public class GitDeltaCalculatorITest extends GitITest {
      * The Git diff file should be created properly.
      */
     @Test
+    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", justification = "The cast is confirmed via an assertion")
     public void shouldCreateDiffFile() {
         GitDeltaCalculator deltaCalculator = createDeltaCalculator();
         FilteredLog log = createLog();
@@ -62,6 +64,7 @@ public class GitDeltaCalculatorITest extends GitITest {
         assertThat(delta).hasCurrentCommit(currentCommit);
         assertThat(delta).hasReferenceCommit(referenceCommit);
         assertThat(delta).isInstanceOf(GitDelta.class);
+
         assertThat(((GitDelta) delta).getDiffFile()).isEqualTo("diff --git a/newFile b/newFile\n"
                 + "new file mode 100644\n"
                 + "index 0000000..6b584e8\n"

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorITest.java
@@ -1,0 +1,273 @@
+package io.jenkins.plugins.forensics.git.delta;
+
+import edu.hm.hafner.util.FilteredLog;
+import io.jenkins.plugins.forensics.assertions.Assertions;
+import io.jenkins.plugins.forensics.delta.model.*;
+import io.jenkins.plugins.forensics.git.util.GitITest;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for the class {@link GitDeltaCalculator}.
+ *
+ * @author Florian Orendi
+ */
+public class GitDeltaCalculatorITest extends GitITest {
+
+    @Test
+    public void shouldCreateEmptyDeltaIfCommitsAreEmpty() {
+        GitDeltaCalculator deltaCalculator = createDeltaCalculator();
+
+        FilteredLog log = createLog();
+        Optional<Delta> delta = deltaCalculator.calculateDelta("", "", log);
+
+        assertThat(delta).isEmpty();
+    }
+
+    @Test
+    public void shouldSetCommitBoundaries() {
+        GitDeltaCalculator deltaCalculator = createDeltaCalculator();
+        FilteredLog log = createLog();
+
+        final String referenceCommit = getHead();
+        commitFile("test");
+        final String currentCommit = getHead();
+
+        Optional<Delta> result = deltaCalculator.calculateDelta(currentCommit, referenceCommit, log);
+        assertThat(result).isNotEmpty();
+
+        Delta delta = result.get();
+        Assertions.assertThat(delta).hasCurrentCommit(currentCommit);
+        Assertions.assertThat(delta).hasReferenceCommit(referenceCommit);
+    }
+
+    @Test
+    public void shouldCreateDiffFile() {
+        GitDeltaCalculator deltaCalculator = createDeltaCalculator();
+        FilteredLog log = createLog();
+
+        final String referenceCommit = getHead();
+        final String fileName = "newFile";
+        final String content = "content";
+        writeFile(fileName, content);
+        addFile(fileName);
+        commit("test");
+        final String currentCommit = getHead();
+
+        Optional<Delta> result = deltaCalculator.calculateDelta(currentCommit, referenceCommit, log);
+        assertThat(result).isNotEmpty();
+
+        Delta delta = result.get();
+        Assertions.assertThat(delta).hasDiffFile("diff --git a/newFile b/newFile\n"
+                + "new file mode 100644\n"
+                + "index 0000000..6b584e8\n"
+                + "--- /dev/null\n"
+                + "+++ b/newFile\n"
+                + "@@ -0,0 +1 @@\n"
+                + "+content\n"
+                + "\\ No newline at end of file\n");
+    }
+
+    @Test
+    public void shouldDetermineAddedFile() {
+        GitDeltaCalculator deltaCalculator = createDeltaCalculator();
+        FilteredLog log = createLog();
+
+        final String referenceCommit = getHead();
+
+        final String newFileName = "newFile";
+        final String content = "added";
+        writeFile(newFileName, content);
+        addFile(newFileName);
+        commit("test");
+        final String currentCommit = getHead();
+
+        Optional<Delta> result = deltaCalculator.calculateDelta(currentCommit, referenceCommit, log);
+        assertThat(result).isNotEmpty();
+
+        Delta delta = result.get();
+        FileChanges fileChanges = getFileChanges(delta);
+        assertThat(fileChanges.getFileName()).isEqualTo(newFileName);
+        assertThat(fileChanges.getFileEditType()).isEqualTo(FileEditType.ADD);
+        assertThat(fileChanges.getFileContent()).isEqualTo(content);
+    }
+
+    @Test
+    public void shouldDetermineModifiedFile() {
+        GitDeltaCalculator deltaCalculator = createDeltaCalculator();
+        FilteredLog log = createLog();
+
+        final String content = "modified";
+        commitFile("test");
+        final String referenceCommit = getHead();
+        commitFile(content);
+        final String currentCommit = getHead();
+
+        Optional<Delta> result = deltaCalculator.calculateDelta(currentCommit, referenceCommit, log);
+        assertThat(result).isNotEmpty();
+
+        Delta delta = result.get();
+        FileChanges fileChanges = getFileChanges(delta);
+        assertThat(fileChanges.getFileName()).isEqualTo(GitITest.INITIAL_FILE);
+        assertThat(fileChanges.getFileEditType()).isEqualTo(FileEditType.MODIFY);
+        assertThat(fileChanges.getFileContent()).isEqualTo(content);
+    }
+
+    @Test
+    public void shouldDetermineDeletedFile() {
+        GitDeltaCalculator deltaCalculator = createDeltaCalculator();
+        FilteredLog log = createLog();
+
+        final String content = "content";
+        commitFile(content);
+        final String referenceCommit = getHead();
+        git("rm", GitITest.INITIAL_FILE);
+        commit("test");
+        final String currentCommit = getHead();
+
+        Optional<Delta> result = deltaCalculator.calculateDelta(currentCommit, referenceCommit, log);
+        assertThat(result).isNotEmpty();
+
+        Delta delta = result.get();
+        FileChanges fileChanges = getFileChanges(delta);
+        assertThat(fileChanges.getFileName()).isEqualTo(GitITest.INITIAL_FILE);
+        assertThat(fileChanges.getFileEditType()).isEqualTo(FileEditType.DELETE);
+        assertThat(fileChanges.getFileContent()).isEqualTo(content);
+    }
+
+    @Test
+    public void shouldDetermineAddedLines() {
+        GitDeltaCalculator deltaCalculator = createDeltaCalculator();
+        FilteredLog log = createLog();
+
+        final String content = "Test\nTest\n";
+        commitFile(content);
+        final String referenceCommit = getHead();
+        commitFile(content + content);
+        final String currentCommit = getHead();
+
+        Optional<Delta> result = deltaCalculator.calculateDelta(currentCommit, referenceCommit, log);
+        assertThat(result).isNotEmpty();
+
+        Delta delta = result.get();
+        FileChanges fileChanges = getFileChanges(delta);
+        Change change = getSingleChangeOfType(fileChanges, ChangeEditType.INSERT);
+        Assertions.assertThat(change.getEditType()).isEqualTo(ChangeEditType.INSERT);
+        assertThat(change.getFromLine()).isEqualTo(3);
+        assertThat(change.getToLine()).isEqualTo(4);
+    }
+
+    @Test
+    public void shouldDetermineModifiedLines() {
+        GitDeltaCalculator deltaCalculator = createDeltaCalculator();
+        FilteredLog log = createLog();
+
+        final String content = "Test\nTest\n";
+        final String modified = "Test\nModified\n";
+        commitFile(content);
+        final String referenceCommit = getHead();
+        commitFile(modified);
+        final String currentCommit = getHead();
+
+        Optional<Delta> result = deltaCalculator.calculateDelta(currentCommit, referenceCommit, log);
+        assertThat(result).isNotEmpty();
+
+        Delta delta = result.get();
+        FileChanges fileChanges = getFileChanges(delta);
+        Change change = getSingleChangeOfType(fileChanges, ChangeEditType.REPLACE);
+        Assertions.assertThat(change.getEditType()).isEqualTo(ChangeEditType.REPLACE);
+        assertThat(change.getFromLine()).isEqualTo(2);
+        assertThat(change.getToLine()).isEqualTo(2);
+    }
+
+    @Test
+    public void shouldDetermineDeletedLines() {
+        GitDeltaCalculator deltaCalculator = createDeltaCalculator();
+        FilteredLog log = createLog();
+
+        final String content = "Test\nTest\n";
+        final String modified = "Test\n";
+        commitFile(content);
+        final String referenceCommit = getHead();
+        commitFile(modified);
+        final String currentCommit = getHead();
+
+        Optional<Delta> result = deltaCalculator.calculateDelta(currentCommit, referenceCommit, log);
+        assertThat(result).isNotEmpty();
+
+        Delta delta = result.get();
+        FileChanges fileChanges = getFileChanges(delta);
+        Change change = getSingleChangeOfType(fileChanges, ChangeEditType.DELETE);
+        Assertions.assertThat(change.getEditType()).isEqualTo(ChangeEditType.DELETE);
+        assertThat(change.getFromLine()).isEqualTo(2);
+        assertThat(change.getToLine()).isEqualTo(2);
+    }
+
+    @Test
+    public void shouldDetermineAllChangeTypesTogether() {
+        GitDeltaCalculator deltaCalculator = createDeltaCalculator();
+        FilteredLog log = createLog();
+
+        final String content = "Test1\nTest2\nTest3\nTest4";
+        final String newContent = "Modified\nTest2\nInserted\nTest3";
+        commitFile(content);
+        final String referenceCommit = getHead();
+        commitFile(newContent);
+        final String currentCommit = getHead();
+
+        Optional<Delta> result = deltaCalculator.calculateDelta(currentCommit, referenceCommit, log);
+        assertThat(result).isNotEmpty();
+
+        Delta delta = result.get();
+        FileChanges fileChanges = getFileChanges(delta);
+
+        Change replace = getSingleChangeOfType(fileChanges, ChangeEditType.REPLACE);
+        Assertions.assertThat(replace.getEditType()).isEqualTo(ChangeEditType.REPLACE);
+        assertThat(replace.getFromLine()).isEqualTo(1);
+        assertThat(replace.getToLine()).isEqualTo(1);
+
+        Change insert = getSingleChangeOfType(fileChanges, ChangeEditType.INSERT);
+        Assertions.assertThat(insert.getEditType()).isEqualTo(ChangeEditType.INSERT);
+        assertThat(insert.getFromLine()).isEqualTo(3);
+        assertThat(insert.getToLine()).isEqualTo(3);
+
+        Change delete = getSingleChangeOfType(fileChanges, ChangeEditType.DELETE);
+        Assertions.assertThat(delete.getEditType()).isEqualTo(ChangeEditType.DELETE);
+        assertThat(delete.getFromLine()).isEqualTo(4);
+        assertThat(delete.getToLine()).isEqualTo(4);
+    }
+
+    private Change getSingleChangeOfType(final FileChanges fileChanges, final ChangeEditType type) {
+        List<Change> changes = fileChanges.getChanges().get(type);
+        assertThat(changes).isNotNull().isNotEmpty();
+        assertThat(changes.size()).isEqualTo(1);
+        return changes.get(0);
+    }
+
+    private FileChanges getFileChanges(final Delta delta) {
+        Optional<FileChanges> fileChanges = delta.getFileChanges().values().stream().findFirst();
+        assertThat(fileChanges).isNotEmpty();
+        return fileChanges.get();
+    }
+
+    private void commitFile(final String content) {
+        writeFile(INITIAL_FILE, content);
+        git("add", INITIAL_FILE);
+        git("config", "user.name", GitITest.FOO_NAME);
+        git("config", "user.email", GitITest.FOO_EMAIL);
+        git("commit", "--message=Test");
+    }
+
+    private FilteredLog createLog() {
+        return new FilteredLog(StringUtils.EMPTY);
+    }
+
+    private GitDeltaCalculator createDeltaCalculator() {
+        return new GitDeltaCalculator(createGitClient());
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorITest.java
@@ -63,16 +63,16 @@ public class GitDeltaCalculatorITest extends GitITest {
         Delta delta = result.get();
         assertThat(delta).hasCurrentCommit(currentCommit);
         assertThat(delta).hasReferenceCommit(referenceCommit);
-        assertThat(delta).isInstanceOf(GitDelta.class);
-
-        assertThat(((GitDelta) delta).getDiffFile()).isEqualTo("diff --git a/newFile b/newFile\n"
-                + "new file mode 100644\n"
-                + "index 0000000..6b584e8\n"
-                + "--- /dev/null\n"
-                + "+++ b/newFile\n"
-                + "@@ -0,0 +1 @@\n"
-                + "+content\n"
-                + "\\ No newline at end of file\n");
+        assertThat(delta).isInstanceOfSatisfying(GitDelta.class,
+                gitDelta -> assertThat(gitDelta.getDiffFile()).isEqualTo(
+                        "diff --git a/newFile b/newFile\n"
+                                + "new file mode 100644\n"
+                                + "index 0000000..6b584e8\n"
+                                + "--- /dev/null\n"
+                                + "+++ b/newFile\n"
+                                + "@@ -0,0 +1 @@\n"
+                                + "+content\n"
+                                + "\\ No newline at end of file\n"));
     }
 
     /**

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorTest.java
@@ -1,0 +1,40 @@
+package io.jenkins.plugins.forensics.git.delta;
+
+import edu.hm.hafner.util.FilteredLog;
+import io.jenkins.plugins.forensics.delta.model.Delta;
+import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the class {@link GitDeltaCalculator}.
+ *
+ * @author Florian Orendi
+ */
+class GitDeltaCalculatorTest {
+
+    @Test
+    void shouldAbortIfWithRepositoryThrowsException() throws IOException, InterruptedException {
+        GitClient gitClient = createGitClientWithException(new IOException());
+        GitDeltaCalculator deltaCalculator = new GitDeltaCalculator(gitClient);
+        FilteredLog log = new FilteredLog(StringUtils.EMPTY);
+
+        Optional<Delta> result = deltaCalculator.calculateDelta("x", "x", log);
+
+        assertThat(result).isEmpty();
+        assertThat(log.getErrorMessages()).contains(GitDeltaCalculator.DELTA_ERROR);
+    }
+
+    private GitClient createGitClientWithException(final Exception exception) throws InterruptedException, IOException {
+        GitClient gitClient = Mockito.mock(GitClient.class);
+        Mockito.when(gitClient.withRepository(ArgumentMatchers.any())).thenThrow(exception);
+        return gitClient;
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/delta/GitDeltaCalculatorTest.java
@@ -1,17 +1,19 @@
 package io.jenkins.plugins.forensics.git.delta;
 
-import edu.hm.hafner.util.FilteredLog;
-import io.jenkins.plugins.forensics.delta.model.Delta;
-import org.apache.commons.lang3.StringUtils;
-import org.jenkinsci.plugins.gitclient.GitClient;
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mockito;
-
 import java.io.IOException;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+
+import edu.hm.hafner.util.FilteredLog;
+
+import org.jenkinsci.plugins.gitclient.GitClient;
+
+import io.jenkins.plugins.forensics.delta.model.Delta;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests for the class {@link GitDeltaCalculator}.
@@ -33,8 +35,8 @@ class GitDeltaCalculatorTest {
     }
 
     private GitClient createGitClientWithException(final Exception exception) throws InterruptedException, IOException {
-        GitClient gitClient = Mockito.mock(GitClient.class);
-        Mockito.when(gitClient.withRepository(ArgumentMatchers.any())).thenThrow(exception);
+        GitClient gitClient = mock(GitClient.class);
+        when(gitClient.withRepository(any())).thenThrow(exception);
         return gitClient;
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/delta/model/GitDeltaTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/delta/model/GitDeltaTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.*;
  *
  * @author Florian Orendi
  */
-public class GitDeltaTest {
+class GitDeltaTest {
 
     private static final String DIFF_FILE = "testContent";
 

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/delta/model/GitDeltaTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/delta/model/GitDeltaTest.java
@@ -1,0 +1,40 @@
+package io.jenkins.plugins.forensics.git.delta.model;
+
+import java.util.HashMap;
+
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Test class for {@link GitDelta}.
+ *
+ * @author Florian Orendi
+ */
+public class GitDeltaTest {
+
+    private static final String DIFF_FILE = "testContent";
+
+    @Test
+    void testGitDeltaGetters() {
+        GitDelta delta = createGitDelta();
+
+        assertThat(delta.getDiffFile()).isEqualTo(DIFF_FILE);
+    }
+
+    @Test
+    void shouldObeyEqualsContract() {
+        EqualsVerifier.simple().forClass(GitDelta.class).verify();
+    }
+
+    /**
+     * Factory method which creates an instance of {@link GitDelta}.
+     *
+     * @return the created instance
+     */
+    private GitDelta createGitDelta() {
+        return new GitDelta("", "", new HashMap<>(), DIFF_FILE);
+    }
+}

--- a/plugin/src/test/resources/design.puml
+++ b/plugin/src/test/resources/design.puml
@@ -7,12 +7,14 @@ skinparam component {
 }
 
 [Blamer] <<..blame..>>
+[Delta] <<..delta..>>
 [Miner] <<..miner>>
 [Reference] <<..reference>>
 
 [Utilities] <<..util>>
 
 [Blamer] --> [Utilities]
+[Delta] --> [Utilities]
 [Miner] --> [Utilities]
 [Miner] -> [Reference]
 [Reference] --> [Utilities]

--- a/ui-tests/pom.xml
+++ b/ui-tests/pom.xml
@@ -122,6 +122,13 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-assertions-generator-maven-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
I expanded the API from the Forensics API Plugin, which can be used for calculating the code difference between two commits, with a Git implementation.
The corresponding Draft Pull Request for the Forensics API Plugin can be found [here](https://github.com/jenkinsci/forensics-api-plugin/pull/372).
