### PR TITLE
Enabled rename detection

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -29,7 +29,7 @@
     <font-awesome-api.version>6.0.0-1</font-awesome-api.version>
     <plugin-util-api.version>2.16.0</plugin-util-api.version>
     <data-tables-api.version>1.11.4-3</data-tables-api.version>
-    <forensics-api-plugin.version>1.12.0</forensics-api-plugin.version>
+    <forensics-api-plugin.version>1.13.0</forensics-api-plugin.version>
     <bootstrap5-api.version>5.1.3-6</bootstrap5-api.version>
     <testcontainers.version>1.17.1</testcontainers.version>
   </properties>


### PR DESCRIPTION
I enabled the rename detection and fixed a bug which cause not unique file IDs for deleted files.
