### PR TITLE
[JENKINS-72317] Use Jenkins.READ permission check for all list box models

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder.java
@@ -163,7 +163,6 @@ public class GitReferenceRecorder extends ReferenceRecorder {
          *
          * @return the model with the possible reference jobs
          */
-        @Override
         @POST
         public ComboBoxModel doFillReferenceJobItems(@AncestorInPath final BuildableItem project) {
             if (jenkins.hasPermission(Item.CONFIGURE, project)) {
@@ -182,7 +181,6 @@ public class GitReferenceRecorder extends ReferenceRecorder {
          *
          * @return the validation result
          */
-        @Override
         @POST
         @SuppressWarnings("unused") // Used in jelly validation
         public FormValidation doCheckReferenceJob(@AncestorInPath final BuildableItem project,

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder.java
@@ -14,7 +14,7 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.POST;
 import org.jenkinsci.Symbol;
 import hudson.Extension;
-import hudson.model.AbstractProject;
+import hudson.model.BuildableItem;
 import hudson.model.Item;
 import hudson.model.Run;
 import hudson.util.ComboBoxModel;
@@ -165,7 +165,7 @@ public class GitReferenceRecorder extends ReferenceRecorder {
          */
         @Override
         @POST
-        public ComboBoxModel doFillReferenceJobItems(@AncestorInPath final AbstractProject<?, ?> project) {
+        public ComboBoxModel doFillReferenceJobItems(@AncestorInPath final BuildableItem project) {
             if (jenkins.hasPermission(Item.CONFIGURE, project)) {
                 return model.getAllJobs();
             }
@@ -185,7 +185,7 @@ public class GitReferenceRecorder extends ReferenceRecorder {
         @Override
         @POST
         @SuppressWarnings("unused") // Used in jelly validation
-        public FormValidation doCheckReferenceJob(@AncestorInPath final AbstractProject<?, ?> project,
+        public FormValidation doCheckReferenceJob(@AncestorInPath final BuildableItem project,
                 @QueryParameter final String referenceJob) {
             if (!jenkins.hasPermission(Item.CONFIGURE, project)) {
                 return FormValidation.ok();

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderTest.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.forensics.git.reference;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import hudson.model.BuildableItem;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.util.ComboBoxModel;
@@ -36,15 +37,15 @@ class GitReferenceRecorderTest {
             Descriptor descriptor = new Descriptor(jenkins, model);
 
             FreeStyleProject project = mock(FreeStyleProject.class);
-            assertThat(descriptor.doCheckReferenceJob(project, JOB_NAME)).isEqualTo(OK);
+            assertThat(descriptor.doCheckReferenceJob((BuildableItem) project, JOB_NAME)).isEqualTo(OK);
             verifyNoInteractions(model);
 
             // Now enable permission
-            when(jenkins.hasPermission(Item.CONFIGURE, project)).thenReturn(true);
+            when(jenkins.hasPermission(Item.CONFIGURE, (BuildableItem)project)).thenReturn(true);
             // first call stub returns ERROR
-            assertThat(descriptor.doCheckReferenceJob(project, JOB_NAME)).isEqualTo(ERROR);
+            assertThat(descriptor.doCheckReferenceJob((BuildableItem) project, JOB_NAME)).isEqualTo(ERROR);
             // second call stub returns ERROR
-            assertThat(descriptor.doCheckReferenceJob(project, JOB_NAME)).isEqualTo(OK);
+            assertThat(descriptor.doCheckReferenceJob((BuildableItem) project, JOB_NAME)).isEqualTo(OK);
         }
 
         @Test
@@ -59,12 +60,12 @@ class GitReferenceRecorderTest {
             Descriptor descriptor = new Descriptor(jenkins, model);
 
             FreeStyleProject project = mock(FreeStyleProject.class);
-            assertThat(descriptor.doFillReferenceJobItems(project)).isEqualTo(new ComboBoxModel());
+            assertThat(descriptor.doFillReferenceJobItems((BuildableItem) project)).isEqualTo(new ComboBoxModel());
             verifyNoInteractions(model);
 
             // Now enable permission
-            when(jenkins.hasPermission(Item.CONFIGURE, project)).thenReturn(true);
-            assertThat(descriptor.doFillReferenceJobItems(project)).isEqualTo(jobs);
+            when(jenkins.hasPermission(Item.CONFIGURE, (BuildableItem)project)).thenReturn(true);
+            assertThat(descriptor.doFillReferenceJobItems((BuildableItem) project)).isEqualTo(jobs);
         }
     }
 }


### PR DESCRIPTION
Additionally, use permissions for a `BuildableItem` in all validations.

See https://issues.jenkins.io/browse/JENKINS-72317 for details.