### PR TITLE
[JENKINS-73380] Add option to consider running builds as reference

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder.java
@@ -12,7 +12,6 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.jenkinsci.Symbol;
 import hudson.Extension;
 import hudson.model.Run;
-import jenkins.scm.api.SCMHead;
 
 import io.jenkins.plugins.forensics.reference.ReferenceRecorder;
 import io.jenkins.plugins.util.JenkinsFacade;
@@ -78,8 +77,7 @@ public class GitReferenceRecorder extends ReferenceRecorder {
     @Override
     protected Optional<Run<?, ?>> find(final Run<?, ?> owner, final Run<?, ?> lastCompletedBuildOfReferenceJob,
             final FilteredLog log) {
-        Optional<GitCommitsRecord> referenceCommit
-                = GitCommitsRecord.findRecordForScm(lastCompletedBuildOfReferenceJob, getScm());
+        var referenceCommit = GitCommitsRecord.findRecordForScm(lastCompletedBuildOfReferenceJob, getScm());
 
         Optional<Run<?, ?>> referenceBuild;
         if (referenceCommit.isPresent()) {
@@ -95,7 +93,7 @@ public class GitReferenceRecorder extends ReferenceRecorder {
             return referenceBuild;
         }
 
-        Optional<SCMHead> targetBranchHead = findTargetBranchHead(owner.getParent());
+        var targetBranchHead = findTargetBranchHead(owner.getParent());
         if (targetBranchHead.isPresent()) {
             log.logInfo("-> falling back to latest build '%s' since a pull or merge request has been detected",
                     lastCompletedBuildOfReferenceJob.getDisplayName());
@@ -108,13 +106,12 @@ public class GitReferenceRecorder extends ReferenceRecorder {
 
     private Optional<Run<?, ?>> findByCommits(final Run<?, ?> owner, final GitCommitsRecord referenceCommit,
             final FilteredLog log) {
-        Optional<GitCommitsRecord> ownerCommits = GitCommitsRecord.findRecordForScm(owner, getScm());
+        var ownerCommits = GitCommitsRecord.findRecordForScm(owner, getScm());
         if (ownerCommits.isPresent()) {
-            GitCommitsRecord commitsRecord = ownerCommits.get();
-            Optional<Run<?, ?>> referencePoint = commitsRecord.getReferencePoint(
-                    referenceCommit, getMaxCommits(), isSkipUnknownCommits(), log);
+            var commitsRecord = ownerCommits.get();
+            var referencePoint = commitsRecord.getReferencePoint(referenceCommit, getMaxCommits(), isSkipUnknownCommits(), log);
             if (referencePoint.isPresent()) {
-                Run<?, ?> referenceBuild = referencePoint.get();
+                var referenceBuild = referencePoint.get();
                 log.logInfo("-> found build '%s' in reference job with matching commits",
                         referenceBuild.getDisplayName());
 

--- a/plugin/src/main/resources/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder/config.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder/config.jelly
@@ -17,11 +17,16 @@
     <f:number default="100"/>
   </f:entry>
 
-  <f:entry field="skipUnknownCommits">
-    <f:checkbox title="${%title.skipUnknownCommits}"/>
+  <f:entry field="skipUnknownCommits" title="${%title.skipUnknownCommits}">
+    <f:checkbox />
   </f:entry>
 
-  <f:entry field="latestBuildIfNotFound">
-    <f:checkbox title="${%title.latestBuildIfNotFound}"/>
+  <f:entry field="latestBuildIfNotFound" title="${%title.latestBuildIfNotFound}">
+    <f:checkbox />
   </f:entry>
+
+  <f:entry title="${%title.considerRunningBuild}" field="considerRunningBuild">
+    <f:checkbox />
+  </f:entry>
+
 </j:jelly>

--- a/plugin/src/main/resources/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder/config.properties
+++ b/plugin/src/main/resources/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder/config.properties
@@ -6,3 +6,4 @@ description.maxCommits=Defines how many commits of a job''s Git history should b
 title.targetBranch=Target Branch
 title.skipUnknownCommits=Ignore reference job builds with commits that are not part of the current build
 title.latestBuildIfNotFound=Fallback to the latest-completed build if no reference build has been found
+title.considerRunningBuild=Consider running builds as reference

--- a/plugin/src/main/resources/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder/help-considerRunningBuild.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorder/help-considerRunningBuild.html
@@ -1,0 +1,3 @@
+If enabled, then running builds will be considered as reference build as well. Otherwise, only completed builds
+are considered. Enabling this option might cause problems if the reference build has not yet all the
+required results available.


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/forensics-api-plugin/pull/557