### PR TITLE
[JENKINS-75429] Ignore the case of the SCM when matching the SCM repository parameter

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCommitsRecord.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCommitsRecord.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.forensics.git.reference;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jgit.lib.ObjectId;
 
 import edu.hm.hafner.util.FilteredLog;
@@ -40,8 +41,9 @@ public class GitCommitsRecord implements RunAction2, Serializable {
      * @return the record with the commits if found, {@link Optional#empty()} otherwise
      */
     public static Optional<GitCommitsRecord> findRecordForScm(final Run<?, ?> build, final String scmKey) {
-        return build.getActions(GitCommitsRecord.class)
-                .stream().filter(record -> record.getScmKey().contains(scmKey)).findAny();
+        return build.getActions(GitCommitsRecord.class).stream()
+                .filter(record -> StringUtils.containsIgnoreCase(record.getScmKey(), scmKey))
+                .findAny();
     }
 
     private transient Run<?, ?> owner;

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/reference/GitReferenceRecorderITest.java
@@ -346,6 +346,26 @@ class GitReferenceRecorderITest extends GitITest {
         verifyPipelineResult(mainBuild, featureBranch);
     }
 
+    @Test
+    @Issue("JENKINS-75429")
+    void shouldMatchCaseInsensitive() {
+        var mainBranch = createPipeline(MAIN);
+        mainBranch.setDefinition(asStage(
+                createForensicsCheckoutStep(),
+                createLocalGitCheckout(MAIN)));
+
+        Run<?, ?> mainBuild = buildSuccessfully(mainBranch);
+
+        createFeatureBranchAndAddCommits();
+
+        var featureBranch = createPipeline(FEATURE);
+        featureBranch.setDefinition(asStage(
+                createLocalGitCheckout(FEATURE),
+                "discoverGitReferenceBuild(referenceJob: '" + MAIN + "', scm: 'GIT FILE')"));
+
+        verifyPipelineResult(mainBuild, featureBranch);
+    }
+
     /**
      * Creates a pipeline for the main branch and another pipeline for the feature branch, builds them and checks if
      * the correct reference build is found. The main branch contains an additional but unrelated SCM


### PR DESCRIPTION
Improve the selection of the correct SCM (see [JENKINS-75429](https://issues.jenkins.io/browse/JENKINS-75429)). It makes sense to ignore the capitilization of the name as it is not relevant on Windows.