### PR TITLE
Restore serialization to use interfaces again

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/BuildCommits.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/BuildCommits.java
@@ -23,8 +23,8 @@ class BuildCommits implements Serializable {
 
     private final String previousBuildCommit;
 
-    @SuppressWarnings("PMD.LooseCoupling")
-    private final ArrayList<String> commits = new ArrayList<>();
+    @SuppressWarnings("serial")
+    private final List<String> commits = new ArrayList<>();
 
     private ObjectId head = ObjectId.zeroId();
     private ObjectId target = ObjectId.zeroId();

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCommitsRecord.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCommitsRecord.java
@@ -58,12 +58,12 @@ public class GitCommitsRecord implements RunAction2, Serializable {
     private final RecordingType recordingType;
     private final String latestCommitLink;
     private final String targetParentCommit;
-    @SuppressWarnings("PMD.LooseCoupling")
-    private final ArrayList<String> commits;
-    @SuppressWarnings("PMD.LooseCoupling")
-    private final ArrayList<String> errorMessages;
-    @SuppressWarnings("PMD.LooseCoupling")
-    private final ArrayList<String> infoMessages;
+    @SuppressWarnings("serial")
+    private final List<String> commits;
+    @SuppressWarnings("serial")
+    private final List<String> errorMessages;
+    @SuppressWarnings("serial")
+    private final List<String> infoMessages;
 
     /** Determines if this record is the starting point or an incremental record that is based on the previous record. */
     enum RecordingType {


### PR DESCRIPTION
Changing the fields to serializable classes breaks the existing serializations.