### PR TITLE
Calling `minerepository()` leads to `org.eclipse.jgit.lib.Repository` close warning

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/blame/GitBlamer.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/blame/GitBlamer.java
@@ -127,30 +127,28 @@ class GitBlamer extends Blamer {
         @Override @SuppressWarnings("PMD.DoNotUseThreads")
         public RemoteResultWrapper<Blames> invoke(final Repository repository, final VirtualChannel channel)
                 throws InterruptedException {
-            try (repository) {
-                RemoteResultWrapper<Blames> log = new RemoteResultWrapper<>(blames, "Errors while running Git blame:");
-                log.logInfo("-> Git commit ID = '%s'", headCommit.getName());
-                log.logInfo("-> Git working tree = '%s'", getWorkTree(repository));
+            RemoteResultWrapper<Blames> log = new RemoteResultWrapper<>(blames, "Errors while running Git blame:");
+            log.logInfo("-> Git commit ID = '%s'", headCommit.getName());
+            log.logInfo("-> Git working tree = '%s'", getWorkTree(repository));
 
-                var blameRunner = new BlameRunner(repository, headCommit);
-                var lastCommitRunner = new LastCommitRunner(repository);
+            var blameRunner = new BlameRunner(repository, headCommit);
+            var lastCommitRunner = new LastCommitRunner(repository);
 
-                var builder = new FileBlameBuilder();
-                for (String file : locations.getFiles()) {
-                    run(builder, file, blameRunner, lastCommitRunner, log);
+            var builder = new FileBlameBuilder();
+            for (String file : locations.getFiles()) {
+                run(builder, file, blameRunner, lastCommitRunner, log);
 
-                    if (Thread.interrupted()) { // Cancel request by user
-                        var message = "Blaming has been interrupted while computing blame information";
-                        log.logInfo(message);
+                if (Thread.interrupted()) { // Cancel request by user
+                    var message = "Blaming has been interrupted while computing blame information";
+                    log.logInfo(message);
 
-                        throw new InterruptedException(message);
-                    }
+                    throw new InterruptedException(message);
                 }
-
-                log.logInfo("-> blamed authors of issues in %d files", blames.size());
-
-                return log;
             }
+
+            log.logInfo("-> blamed authors of issues in %d files", blames.size());
+
+            return log;
         }
 
         /**

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/MergeBaseSelector.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/MergeBaseSelector.java
@@ -36,15 +36,16 @@ class MergeBaseSelector implements RepositoryCallback<String> {
 
         var target = repository.resolve(latestCommit);
 
-        var walk = new RevWalk(repository);
-        walk.setRevFilter(RevFilter.MERGE_BASE);
-        walk.markStart(repository.parseCommit(head));
-        walk.markStart(repository.parseCommit(target));
+        try (var walk = new RevWalk(repository)) {
+            walk.setRevFilter(RevFilter.MERGE_BASE);
+            walk.markStart(repository.parseCommit(head));
+            walk.markStart(repository.parseCommit(target));
 
-        var next = walk.next();
-        if (next == null) {
-            return latestCommit;
+            var next = walk.next();
+            if (next == null) {
+                return latestCommit;
+            }
+            return next.getId().getName();
         }
-        return next.getId().getName();
     }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/RepositoryStatisticsCallback.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/RepositoryStatisticsCallback.java
@@ -41,15 +41,13 @@ class RepositoryStatisticsCallback
         RemoteResultWrapper<ArrayList<CommitDiffItem>> wrapper = new RemoteResultWrapper<>(
                 commits, "Errors while mining the Git repository:");
 
-        try (repository) {
-            try (var git = new Git(repository)) {
-                var commitAnalyzer = new CommitAnalyzer();
-                commits.addAll(commitAnalyzer.run(repository, git, previousCommitId, wrapper));
-            }
-            catch (IOException | GitAPIException exception) {
-                wrapper.logException(exception,
-                        "Can't analyze commits for the repository " + repository.getIdentifier());
-            }
+        try (var git = new Git(repository)) {
+            var commitAnalyzer = new CommitAnalyzer();
+            commits.addAll(commitAnalyzer.run(repository, git, previousCommitId, wrapper));
+        }
+        catch (IOException | GitAPIException exception) {
+            wrapper.logException(exception,
+                    "Can't analyze commits for the repository " + repository.getIdentifier());
         }
 
         return wrapper;

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCommitsCollector.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/reference/GitCommitsCollector.java
@@ -92,6 +92,8 @@ class GitCommitsCollector extends AbstractRepositoryCallback<RemoteResultWrapper
         if (head == null) {
             throw new IOException("No HEAD commit found in " + repository);
         }
-        return new RevWalk(repository).parseCommit(head);
+        try (var walk = new RevWalk(repository)) {
+            return walk.parseCommit(head);
+        }
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/blame/GitBlamerTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/blame/GitBlamerTest.java
@@ -356,4 +356,20 @@ class GitBlamerTest {
         assertThat(request.getCommit(line)).isEqualTo(getCommitID(TIME + line));
         assertThat(request.getTime(line)).isEqualTo(TIME + line);
     }
+
+    @Test
+    @Issue("JENKINS-74804")
+    void blameCallbackInvokeShouldNotCloseTheRepository() throws InterruptedException {
+        var repository = mock(org.eclipse.jgit.lib.Repository.class);
+    
+        when(repository.getWorkTree()).thenReturn(new java.io.File("/"));
+
+        var locations = new FileLocations();   
+        var blames = new Blames();
+        var callback = new BlameCallback(locations, blames, mock(ObjectId.class));
+
+        callback.invoke(repository, mock(VirtualChannel.class));
+
+        verify(repository, never()).close();
+    }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/blame/GitBlamerTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/blame/GitBlamerTest.java
@@ -359,7 +359,7 @@ class GitBlamerTest {
     }
 
     @Test
-    @SuppressWarnings("PMD.ClosedResource")
+    @SuppressWarnings("PMD.CloseResource")
     @Issue("JENKINS-74804")
     void blameCallbackInvokeShouldNotCloseTheRepository() throws InterruptedException {
         var repository = mock(Repository.class);

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/blame/GitBlamerTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/blame/GitBlamerTest.java
@@ -13,6 +13,7 @@ import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.Issue;
+import org.eclipse.jgit.lib.Repository;
 
 import edu.hm.hafner.util.FilteredLog;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -358,11 +359,12 @@ class GitBlamerTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.ClosedResource")
     @Issue("JENKINS-74804")
     void blameCallbackInvokeShouldNotCloseTheRepository() throws InterruptedException {
-        var repository = mock(org.eclipse.jgit.lib.Repository.class);
+        var repository = mock(Repository.class);
     
-        when(repository.getWorkTree()).thenReturn(new java.io.File("/"));
+        when(repository.getWorkTree()).thenReturn(new File("/"));
 
         var locations = new FileLocations();   
         var blames = new Blames();

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/miner/RepositoryStatisticsCallbackTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/miner/RepositoryStatisticsCallbackTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.*;
 class RepositoryStatisticsCallbackTest {
 
     @Test
-    @SuppressWarnings("PMD.ClosedResource")
+    @SuppressWarnings("PMD.CloseResource")
     @Issue("JENKINS-74804")
     void invokeShouldNotCloseTheRepository() throws Exception {
         var repository = mock(Repository.class);

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/miner/RepositoryStatisticsCallbackTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/miner/RepositoryStatisticsCallbackTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.*;
  * @author Akash Manna
  */
 class RepositoryStatisticsCallbackTest {
-
     @Test
     @SuppressWarnings("PMD.CloseResource")
     @Issue("JENKINS-74804")

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/miner/RepositoryStatisticsCallbackTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/miner/RepositoryStatisticsCallbackTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.*;
 class RepositoryStatisticsCallbackTest {
 
     @Test
+    @SuppressWarnings("PMD.ClosedResource")
     @Issue("JENKINS-74804")
     void invokeShouldNotCloseTheRepository() throws Exception {
         var repository = mock(Repository.class);

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/miner/RepositoryStatisticsCallbackTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/miner/RepositoryStatisticsCallbackTest.java
@@ -1,0 +1,30 @@
+package io.jenkins.plugins.forensics.git.miner;
+
+import org.eclipse.jgit.lib.Repository;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.Issue;
+
+import hudson.remoting.VirtualChannel;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the class {@link RepositoryStatisticsCallback}.
+ *
+ * @author Akash Manna
+ */
+class RepositoryStatisticsCallbackTest {
+
+    @Test
+    @Issue("JENKINS-74804")
+    void invokeShouldNotCloseTheRepository() throws Exception {
+        var repository = mock(Repository.class);
+        when(repository.resolve(anyString())).thenReturn(null);
+
+        var callback = new RepositoryStatisticsCallback("some-previous-commit");
+
+        callback.invoke(repository, mock(VirtualChannel.class));
+
+        verify(repository, never()).close();
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Calling `minerepository()` leads to `org.eclipse.jgit.lib.Repository` close warning

See : https://github.com/jenkinsci/forensics-api-plugin/issues/689
Compare with : https://github.com/jenkinsci/forensics-api-plugin/pull/734
### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
