### PR TITLE
Remove obsolete incremental Maven configuration

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,3 +1,2 @@
 -Dchangelist.format=%d.v%s
--Pconsume-incrementals
 -Pmight-produce-incrementals

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -144,23 +144,6 @@
     </dependency>
 
   </dependencies>
-  <repositories>
-    <repository>
-      <id>incrementals.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/incrementals/</url>
-    </repository>
-    <repository>
-      <id>repo.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/public/</url>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>repo.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/public/</url>
-    </pluginRepository>
-  </pluginRepositories>
 
   <build>
     <plugins>

--- a/ui-tests/pom.xml
+++ b/ui-tests/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>acceptance-test-harness</artifactId>
-      <version>6700.ve944d7df2350</version>
+      <version>6724.v091f4822e6f3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/ui-tests/pom.xml
+++ b/ui-tests/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>acceptance-test-harness</artifactId>
-      <version>6724.v091f4822e6f3</version>
+      <version>6724.va_7c5c4b_fcf9c</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/ui-tests/pom.xml
+++ b/ui-tests/pom.xml
@@ -12,7 +12,7 @@
   <groupId>io.jenkins.plugins</groupId>
   <artifactId>git-forensics-ui-tests</artifactId>
   <packaging>jar</packaging>
-  <version>UNVERSIONED</version>
+  <version>UNVERSIONED-SNAPSHOT</version>
   <name>UI Tests of Git Forensics Plugin</name>
 
   <properties>
@@ -87,10 +87,6 @@
       <id>maven.jenkins-ci.org</id>
       <url>https://repo.jenkins-ci.org/releases/</url>
     </repository>
-    <repository>
-      <id>incrementals.jenkins-ci.org</id>
-      <url>https://repo.jenkins-ci.org/incrementals/</url>
-    </repository>
   </repositories>
 
   <pluginRepositories>
@@ -153,12 +149,6 @@
       <properties>
         <maven.test.skip>false</maven.test.skip>
       </properties>
-    </profile>
-    <profile>
-      <id>consume-incrementals</id>
-    </profile>
-    <profile>
-      <id>might-produce-incrementals</id>
     </profile>
   </profiles>
 


### PR DESCRIPTION
Followup to https://github.com/jenkinsci/warnings-ng-plugin/pull/3382