### PR TITLE
Use merge base with target branch as miner baseline

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/GitMinerFactory.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/GitMinerFactory.java
@@ -28,7 +28,7 @@ public class GitMinerFactory extends MinerFactory {
         if (validator.isFullGitRepository()) {
             logger.logInfo("-> Git miner successfully created in working tree '%s'", workTree);
 
-            return Optional.of(new GitRepositoryMiner(validator.createClient()));
+            return Optional.of(new GitRepositoryMiner(validator.createClient(), build, scm));
         }
         logger.logInfo("-> Git miner could not be created for SCM '%s' in working tree '%s'", scm, workTree);
         return Optional.empty();

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/GitRepositoryMiner.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/GitRepositoryMiner.java
@@ -1,5 +1,7 @@
 package io.jenkins.plugins.forensics.git.miner;
 
+import org.apache.commons.lang3.StringUtils;
+
 import edu.hm.hafner.util.FilteredLog;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -10,8 +12,16 @@ import java.util.Collections;
 import java.util.List;
 
 import org.jenkinsci.plugins.gitclient.GitClient;
+import hudson.model.Run;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.util.BuildData;
+import hudson.scm.SCM;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHead.HeadByItem;
+import jenkins.scm.api.mixin.ChangeRequestSCMHead;
 
 import io.jenkins.plugins.forensics.git.util.RemoteResultWrapper;
+import io.jenkins.plugins.forensics.miner.Baseline;
 import io.jenkins.plugins.forensics.miner.CommitDiffItem;
 import io.jenkins.plugins.forensics.miner.CommitStatistics;
 import io.jenkins.plugins.forensics.miner.RepositoryMiner;
@@ -33,11 +43,15 @@ public class GitRepositoryMiner extends RepositoryMiner {
 
     @SuppressWarnings("serial")
     private final GitClient gitClient;
+    private transient Run<?, ?> build;
+    private transient SCM scm;
 
-    GitRepositoryMiner(final GitClient gitClient) {
+    GitRepositoryMiner(final GitClient gitClient, final Run<?, ?> build, final SCM scm) {
         super();
 
         this.gitClient = gitClient;
+        this.build = build;
+        this.scm = scm;
     }
 
     @Override
@@ -46,10 +60,13 @@ public class GitRepositoryMiner extends RepositoryMiner {
             throws InterruptedException {
         try {
             long nano = System.nanoTime();
+
+            String baseline = resolveBaseline(previous, logger);
+
             logger.logInfo("Analyzing the commit log of the Git repository '%s'",
                     gitClient.getWorkTree());
             RemoteResultWrapper<ArrayList<CommitDiffItem>> wrapped = gitClient.withRepository(
-                    new RepositoryStatisticsCallback(previous.getLatestCommitId()));
+                    new RepositoryStatisticsCallback(baseline));
             logger.merge(wrapped);
 
             List<CommitDiffItem> commits = wrapped.getResult();
@@ -58,13 +75,15 @@ public class GitRepositoryMiner extends RepositoryMiner {
 
             String latestCommitId;
             if (commits.isEmpty()) {
-                latestCommitId = previous.getLatestCommitId();
+                latestCommitId = baseline;
             }
             else {
                 latestCommitId = commits.get(0).getId();
             }
             var current = new RepositoryStatistics(latestCommitId);
-            current.addAll(previous);
+            if (baseline.equals(previous.getLatestCommitId())) {
+                current.addAll(previous);
+            }
             Collections.reverse(commits); // make sure that we start with old commits to preserve the history
             current.addAll(commits);
             return current;
@@ -74,5 +93,101 @@ public class GitRepositoryMiner extends RepositoryMiner {
                     "Exception occurred while mining the Git repository using GitClient");
             return new RepositoryStatistics();
         }
+    }
+
+    private String resolveBaseline(final RepositoryStatistics previous, final FilteredLog logger) {
+        if (getBaseline() == Baseline.TARGET) {
+            try {
+                var targetBaseline = resolveTargetBaseline(logger);
+                if (StringUtils.isNotBlank(targetBaseline)) {
+                    logger.logInfo("-> Using commit '%s' as baseline", targetBaseline);
+                    return targetBaseline;
+                }
+                logger.logInfo("-> No target branch found, falling back to previous build as baseline");
+            }
+            catch (IOException | InterruptedException exception) {
+                logger.logException(exception,
+                        "Exception occurred while resolving the target branch of the Git repository");
+            }
+        }
+        return previous.getLatestCommitId();
+    }
+
+    private String resolveTargetBaseline(final FilteredLog logger) throws IOException, InterruptedException {
+        var targetBranch = resolveTargetBranch(logger);
+        if (StringUtils.isNotBlank(targetBranch)) {
+            return gitClient.withRepository(new TargetBranchSelector(targetBranch));
+        }
+        var targetHead = resolveTargetHeadFromBuildData(logger);
+        if (StringUtils.isNotBlank(targetHead)) {
+            return gitClient.withRepository(new MergeBaseSelector(targetHead));
+        }
+        return StringUtils.EMPTY;
+    }
+
+    private String resolveTargetHeadFromBuildData(final FilteredLog logger) {
+        if (build == null) {
+            return StringUtils.EMPTY;
+        }
+        for (var buildData : build.getActions(BuildData.class)) {
+            if (!matchesScm(buildData)) {
+                continue;
+            }
+            var revision = buildData.getLastBuiltRevision();
+            if (revision == null) {
+                continue;
+            }
+            var branches = revision.getBranches();
+            if (branches == null || branches.isEmpty()) {
+                continue;
+            }
+            for (var branch : branches) {
+                var head = branch.getSHA1String();
+                if (!head.equals(revision.getSha1String())) {
+                    logger.logInfo("-> Detected target branch head '%s' from Git build data", head);
+                    return head;
+                }
+            }
+        }
+        return StringUtils.EMPTY;
+    }
+
+    private boolean matchesScm(final BuildData buildData) {
+        var scmName = buildData.getScmName();
+        if (StringUtils.isNotBlank(scmName) && scm != null) {
+            return scmName.equals(scm.getKey());
+        }
+        var remoteUrls = buildData.getRemoteUrls();
+        if (remoteUrls == null || remoteUrls.isEmpty()) {
+            return true; // no URL information to disambiguate, assume a single SCM
+        }
+        if (scm instanceof GitSCM gitScm) {
+            for (var repository : gitScm.getRepositories()) {
+                for (var uri : repository.getURIs()) {
+                    if (remoteUrls.contains(stripGitSuffix(uri.toString()))) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private String stripGitSuffix(final String url) {
+        return url.replaceAll("/+$", "").replaceAll("[.]git$", "");
+    }
+
+    private String resolveTargetBranch(final FilteredLog logger) {
+        if (build == null) {
+            return StringUtils.EMPTY;
+        }
+        var head = HeadByItem.findHead(build.getParent());
+        if (head instanceof ChangeRequestSCMHead changeRequestHead) {
+            var target = changeRequestHead.getTarget();
+            logger.logInfo("-> Detected a change request for target branch '%s'", target.getName());
+            return target.getName();
+        }
+        logger.logInfo("-> No multibranch change request head detected");
+        return StringUtils.EMPTY;
     }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/MergeBaseSelector.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/MergeBaseSelector.java
@@ -35,11 +35,14 @@ class MergeBaseSelector implements RepositoryCallback<String> {
         }
 
         var target = repository.resolve(latestCommit);
+        if (target == null) {
+            return "";
+        }
 
         try (var walk = new RevWalk(repository)) {
             walk.setRevFilter(RevFilter.MERGE_BASE);
-            walk.markStart(repository.parseCommit(head));
-            walk.markStart(repository.parseCommit(target));
+            walk.markStart(walk.parseCommit(head));
+            walk.markStart(walk.parseCommit(target));
 
             var next = walk.next();
             if (next == null) {

--- a/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/TargetBranchSelector.java
+++ b/plugin/src/main/java/io/jenkins/plugins/forensics/git/miner/TargetBranchSelector.java
@@ -1,0 +1,66 @@
+package io.jenkins.plugins.forensics.git.miner;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.revwalk.filter.RevFilter;
+
+import java.io.IOException;
+import java.io.Serial;
+
+import org.jenkinsci.plugins.gitclient.RepositoryCallback;
+import hudson.remoting.VirtualChannel;
+
+/**
+ * Finds the merge base of the current {@code HEAD} and the head of a target branch. The target branch is resolved
+ * using the common local and remote-tracking ref names.
+ *
+ * @author Michael Trimarchi
+ */
+class TargetBranchSelector implements RepositoryCallback<String> {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private final String targetBranch;
+
+    TargetBranchSelector(final String targetBranch) {
+        this.targetBranch = targetBranch;
+    }
+
+    @Override
+    public String invoke(final Repository repository, final VirtualChannel channel) throws IOException {
+        var head = repository.resolve(Constants.HEAD);
+        if (head == null) {
+            return StringUtils.EMPTY;
+        }
+        var target = resolveTarget(repository);
+        if (target == null) {
+            return StringUtils.EMPTY;
+        }
+        try (var walk = new RevWalk(repository)) {
+            walk.setRevFilter(RevFilter.MERGE_BASE);
+            walk.markStart(walk.parseCommit(head));
+            walk.markStart(walk.parseCommit(target));
+            var next = walk.next();
+            return next == null ? target.getName() : next.getName();
+        }
+    }
+
+    private ObjectId resolveTarget(final Repository repository) throws IOException {
+        var candidates = new String[] {
+            targetBranch,
+            "origin/" + targetBranch,
+            "refs/remotes/origin/" + targetBranch,
+            "refs/heads/" + targetBranch
+        };
+        for (String candidate : candidates) {
+            var resolved = repository.resolve(candidate);
+            if (resolved != null) {
+                return resolved;
+            }
+        }
+        return null;
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/miner/GitRepositoryMinerITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/miner/GitRepositoryMinerITest.java
@@ -101,7 +101,7 @@ class GitRepositoryMinerITest extends GitITest {
     }
 
     private RepositoryStatistics createRepositoryStatistics() throws InterruptedException {
-        return new GitRepositoryMiner(createGitClient()).mine(new RepositoryStatistics(), LOG);
+        return new GitRepositoryMiner(createGitClient(), null, null).mine(new RepositoryStatistics(), LOG);
     }
 
     private void assertDefaultFileStatistics(final RepositoryStatistics statistics) {

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/miner/MergeBaseSelectorITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/miner/MergeBaseSelectorITest.java
@@ -1,0 +1,44 @@
+package io.jenkins.plugins.forensics.git.miner;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import io.jenkins.plugins.forensics.git.util.GitITest;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Tests the class {@link MergeBaseSelector}.
+ *
+ * @author Michael Trimarchi
+ */
+class MergeBaseSelectorITest extends GitITest {
+    @Test
+    void shouldFindCorrectMergeBaseForDirectParent() throws IOException, InterruptedException {
+        writeFileAsAuthorFoo("First\n");
+        var target = getHead();
+        writeFileAsAuthorFoo("Second\n");
+        var head = getHead();
+
+        var mergeBase = createGitClient().withRepository(new MergeBaseSelector(target));
+
+        assertThat(mergeBase).isEqualTo(target);
+        assertThat(head).isNotEqualTo(target);
+    }
+
+    @Test
+    void shouldFindCorrectMergeBaseForAncestor() throws IOException, InterruptedException {
+        writeFileAsAuthorFoo("First\n");
+        writeFileAsAuthorFoo("Second\n");
+        var target = getHead();
+        writeFileAsAuthorFoo("Third\n");
+        writeFileAsAuthorFoo("Fourth\n");
+        var head = getHead();
+
+        var mergeBase = createGitClient().withRepository(new MergeBaseSelector(target));
+
+        assertThat(mergeBase).isEqualTo(target);
+        assertThat(head).isNotEqualTo(target);
+    }
+}

--- a/plugin/src/test/java/io/jenkins/plugins/forensics/git/miner/TargetBranchSelectorITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/forensics/git/miner/TargetBranchSelectorITest.java
@@ -1,0 +1,32 @@
+package io.jenkins.plugins.forensics.git.miner;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import io.jenkins.plugins.forensics.git.util.GitITest;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Tests the class {@link TargetBranchSelector}.
+ *
+ * @author Michael Trimarchi
+ */
+class TargetBranchSelectorITest extends GitITest {
+    @Test
+    void shouldFindMergeBaseOfHeadAndTargetBranch() throws IOException, InterruptedException {
+        var base = getHead();
+
+        checkoutNewBranch("target");
+        checkout(INITIAL_BRANCH);
+
+        writeFileAsAuthorFoo("First\n");
+        var head = getHead();
+
+        var mergeBase = createGitClient().withRepository(new TargetBranchSelector("target"));
+
+        assertThat(mergeBase).isEqualTo(base);
+        assertThat(head).isNotEqualTo(base);
+    }
+}


### PR DESCRIPTION
Implement the `TARGET` baseline option in the repository miner.

When selected, the miner determines the target branch or target head for the current change request using `ChangeRequestSCMHead` or Git build data, and calculates the merge base with `HEAD`. Mining then starts from this merge base instead of using the previous build's head as the baseline.

### Testing done

Tested on gerrit trigger, and collect-git plugin allow to create an scm object. The changes allow to calculate not
on previus build but on real commits that were addedd in the build compared to the baseline

<img width="1852" height="685" alt="image" src="https://github.com/user-attachments/assets/03bf2a9f-1b33-45ec-b647-2a33b3441e70" />


### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
